### PR TITLE
Drop python 3.4 and 3.5 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,18 +42,6 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: lint
-  py34-core:
-    <<: *common
-    docker:
-      - image: circleci/python:3.4
-        environment:
-          TOXENV: py34-core
-  py35-core:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-core
   py36-core:
     <<: *common
     docker:
@@ -71,7 +59,5 @@ workflows:
   test:
     jobs:
       - lint
-      - py34-core
-      - py35-core
       - py36-core
       - py37-core

--- a/setup.py
+++ b/setup.py
@@ -38,15 +38,13 @@ setup(
     package_data={'py_ecc': ['py.typed']},
     install_requires=[
     ],
-    python_requires='>=3.4, <4',
+    python_requires='>=3.6, <4',
     extras_require=extras_require,
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: PyPy',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{34,35,36,37}-core
+    py{36,37}-core
     lint
 
 [flake8]
@@ -16,8 +16,6 @@ passenv=
 deps =
 extras = test
 basepython =
-    py34: python3.4
-    py35: python3.5
     py36: python3.6
     py37: python3.7
 


### PR DESCRIPTION
Part of https://github.com/ethereum/py_ecc/issues/11 fixes, raised after https://github.com/ethereum/py_ecc/pull/18#issuecomment-433678030

Tested against code, works well!
![screenshot from 2018-10-28 13-17-26](https://user-images.githubusercontent.com/33374180/47613374-487e3800-dab4-11e8-8435-9775942915a3.png)
