### PR TITLE
Ensure recursion limit is not reduced

### DIFF
--- a/py_ecc/__init__.py
+++ b/py_ecc/__init__.py
@@ -1,5 +1,9 @@
-from __future__ import absolute_import
+import sys
 
-from . import secp256k1  # noqa: F401
-from . import bn128  # noqa: F401
-from . import optimized_bn128  # noqa: F401
+
+sys.setrecursionlimit(max(10000, sys.getrecursionlimit()))
+
+
+from py_ecc import secp256k1  # noqa: F401
+from py_ecc import bn128  # noqa: F401
+from py_ecc import optimized_bn128  # noqa: F401

--- a/py_ecc/bn128/bn128_field_elements.py
+++ b/py_ecc/bn128/bn128_field_elements.py
@@ -1,16 +1,11 @@
 from __future__ import absolute_import
 
-import sys
-
 from typing import (
     cast,
     List,
     Sequence,
     Union,
 )
-
-
-sys.setrecursionlimit(10000)
 
 
 # The prime modulus of the field


### PR DESCRIPTION
### What was wrong

The way the recurrsion limit was being set it could end up lowing the limit.

### How was it fixed

Added a `max` to the logic to ensure it doesn't lower the current limit.