### PR TITLE
Fix extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 extras_require = {
     'test': [
-        "pytest===3.2.2",
+        "pytest==3.2.2",
         "pytest-xdist"
     ],
     'lint': [


### PR DESCRIPTION
### What was wrong?
#36

### How was it fixed?
Thanks to @andrevmatos: https://github.com/ethereum/py_ecc/issues/36#issuecomment-446180695
`pytest===3.2.2` -> `pytest==3.2.2`

#### Cute Animal Picture

🙀