### PR TITLE
Bring Python3.5 back

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: lint
+  py35-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35-core
   py36-core:
     <<: *common
     docker:
@@ -59,5 +65,6 @@ workflows:
   test:
     jobs:
       - lint
+      - py35-core
       - py36-core
       - py37-core

--- a/setup.py
+++ b/setup.py
@@ -39,13 +39,14 @@ setup(
     package_data={'py_ecc': ['py.typed']},
     install_requires=[
     ],
-    python_requires='>=3.6, <4',
+    python_requires='>=3.5, <4',
     extras_require=extras_require,
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: PyPy',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{36,37}-core
+    py{35,36,37}-core
     lint
 
 [flake8]
@@ -16,6 +16,7 @@ passenv=
 deps =
 extras = test
 basepython =
+    py35: python3.5
     py36: python3.6
     py37: python3.7
 


### PR DESCRIPTION
### What was wrong?
We need Python3.5 for supporting other packages before a series of upgrades.

### How was it fixed?
Bring Python 3.5 back from ethereum/py_ecc#22.

#### Cute Animal Picture
🙀