### PR TITLE
Modernize release process

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0-alpha.0
+current_version = 1.4.5
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,13 @@ test-all:
 	tox
 
 release: clean
-	python setup.py sdist bdist_wheel upload
+	CURRENT_SIGN_SETTING=$(git config commit.gpgSign)
+	git config commit.gpgSign true
+	bumpversion $(bump)
+	git push upstream && git push upstream --tags
+	python setup.py sdist bdist_wheel
+	twine upload dist/*
+	git config commit.gpgSign "$(CURRENT_SIGN_SETTING)"
 
 dist: clean
 	python setup.py sdist bdist_wheel

--- a/README.md
+++ b/README.md
@@ -25,3 +25,25 @@ Feel free to create issue under https://github.com/ethereum/py_ecc/issues
 
 ## Copyright and Licensing
 Project is licensed under the MIT license.
+
+
+## Release setup
+
+To release a new version:
+
+```sh
+make release bump=$$VERSION_PART_TO_BUMP$$
+```
+
+#### How to bumpversion
+
+The version format for this repo is `{major}.{minor}.{patch}` for stable, and
+`{major}.{minor}.{patch}-{stage}.{devnum}` for unstable (`stage` can be alpha or beta).
+
+To issue the next version in line, specify which part to bump,
+like `make release bump=minor` or `make release bump=devnum`.
+
+If you are in a beta version, `make release bump=stage` will switch to a stable.
+
+To issue an unstable version when the current version is stable, specify the
+new version explicitly, like `make release bump="--new-version 4.0.0-alpha.1 devnum"`

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ extras_require = {
     ],
     'dev': [
         "bumpversion>=0.5.3,<1",
-        'twine',
+        "twine",
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,15 @@ extras_require = {
         "flake8==3.4.1",
         "mypy==0.641",
     ],
+    'dev': [
+        "bumpversion>=0.5.3,<1",
+        'twine',
+    ],
 }
 
 
 extras_require['dev'] = (
+    extras_require['dev'] +
     extras_require['test'] +
     extras_require['lint']
 )
@@ -27,6 +32,7 @@ with open('LICENSE') as f:
 
 setup(
     name='py_ecc',
+    # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
     version='1.4.5',
     description='Elliptic curve crypto in python including secp256k1 and alt_bn128',
     long_description=readme,


### PR DESCRIPTION
### What was wrong?

Old manual (error prone) release process

### How was it fixed?

Modernized to use bumpversion 
