### PR TITLE
Add __mod__ to FQ and FQP for type hinting

### DIFF
--- a/py_ecc/optimized_bn128/optimized_field_elements.py
+++ b/py_ecc/optimized_bn128/optimized_field_elements.py
@@ -66,6 +66,9 @@ class FQ(object):
         on = other.n if isinstance(other, FQ) else other
         return FQ((self.n - on) % field_modulus)
 
+    def __mod__(self, other: Union[int, "FQ"]) -> "FQ":
+        return self.__mod__(other)
+
     def __div__(self, other: IntOrFQ) -> "FQ":
         on = other.n if isinstance(other, FQ) else other
         assert isinstance(on, int)
@@ -170,6 +173,9 @@ class FQP(object):
             for x, y
             in zip(self.coeffs, other.coeffs)
         ])
+
+    def __mod__(self, other: Union[int, "FQP"]) -> "FQP":
+        return self.__mod__(other)
 
     def __mul__(self, other: Union[int, "FQP"]) -> "FQP":
         if isinstance(other, int):


### PR DESCRIPTION
### What was wrong?
For type hinting, it requires `__mod__` to return the correct 

### How was it fixed?
Add `__mod__` for `FQP` for type hinting.

#### Cute Animal Picture

Also, on Py-EVM side, https://github.com/hwwhww/py-evm/commit/a326a0e90c9dddad184b0dd05e018bf40df9a719 would work with this PR.
