### PR TITLE
Fix misconfigured checks for point at infinity

### DIFF
--- a/py_ecc/bls12_381/bls12_381_curve.py
+++ b/py_ecc/bls12_381/bls12_381_curve.py
@@ -63,6 +63,8 @@ assert is_on_curve(G2, b2)
 
 # Elliptic curve doubling
 def double(pt):
+    if is_inf(pt):
+        return pt
     x, y = pt
     m = 3 * x**2 / (2 * y)
     newx = m**2 - 2 * x

--- a/py_ecc/bn128/bn128_curve.py
+++ b/py_ecc/bn128/bn128_curve.py
@@ -71,6 +71,8 @@ assert is_on_curve(cast(Point2D[FQ2], G2), b2)
 
 # Elliptic curve doubling
 def double(pt: Point2D[Field]) -> Point2D[Field]:
+    if is_inf(pt):
+        return pt
     x, y = pt
     m = 3 * x**2 / (2 * y)
     newx = m**2 - 2 * x

--- a/py_ecc/optimized_bls12_381/optimized_curve.py
+++ b/py_ecc/optimized_bls12_381/optimized_curve.py
@@ -134,15 +134,15 @@ w = FQ12([0, 1] + [0] * 10)
 
 # Convert P => -P
 def neg(pt):
-    if pt is None:
-        return None
+    if is_inf(pt):
+        return pt
     x, y, z = pt
     return (x, -y, z)
 
 
 def twist(pt):
-    if pt is None:
-        return None
+    if is_inf(pt):
+        return pt
     _x, _y, _z = pt
     # Field isomorphism from Z[p] / x**2 to Z[p] / x**2 - 2*x + 2
     xcoeffs = [_x.coeffs[0] - _x.coeffs[1], _x.coeffs[1]]

--- a/py_ecc/optimized_bls12_381/optimized_curve.py
+++ b/py_ecc/optimized_bls12_381/optimized_curve.py
@@ -141,8 +141,6 @@ def neg(pt):
 
 
 def twist(pt):
-    if is_inf(pt):
-        return pt
     _x, _y, _z = pt
     # Field isomorphism from Z[p] / x**2 to Z[p] / x**2 - 2*x + 2
     xcoeffs = [_x.coeffs[0] - _x.coeffs[1], _x.coeffs[1]]

--- a/py_ecc/optimized_bls12_381/optimized_curve.py
+++ b/py_ecc/optimized_bls12_381/optimized_curve.py
@@ -134,8 +134,6 @@ w = FQ12([0, 1] + [0] * 10)
 
 # Convert P => -P
 def neg(pt):
-    if is_inf(pt):
-        return pt
     x, y, z = pt
     return (x, -y, z)
 

--- a/py_ecc/optimized_bn128/optimized_curve.py
+++ b/py_ecc/optimized_bn128/optimized_curve.py
@@ -142,15 +142,15 @@ w = FQ12([0, 1] + [0] * 10)
 
 # Convert P => -P
 def neg(pt: Optimized_Point3D[Optimized_Field]) -> Optimized_Point3D[Optimized_Field]:
-    if pt is None:
-        return None
+    if is_inf(pt):
+        return pt
     x, y, z = pt
     return (x, -y, z)
 
 
 def twist(pt: Optimized_Point3D[FQP]) -> Optimized_Point3D[FQP]:
-    if pt is None:
-        return None
+    if is_inf(pt):
+        return pt
     _x, _y, _z = pt
     # Field isomorphism from Z[p] / x**2 to Z[p] / x**2 - 18*x + 82
     xcoeffs = [_x.coeffs[0] - _x.coeffs[1] * 9, _x.coeffs[1]]

--- a/py_ecc/optimized_bn128/optimized_curve.py
+++ b/py_ecc/optimized_bn128/optimized_curve.py
@@ -149,8 +149,6 @@ def neg(pt: Optimized_Point3D[Optimized_Field]) -> Optimized_Point3D[Optimized_F
 
 
 def twist(pt: Optimized_Point3D[FQP]) -> Optimized_Point3D[FQP]:
-    if is_inf(pt):
-        return pt
     _x, _y, _z = pt
     # Field isomorphism from Z[p] / x**2 to Z[p] / x**2 - 18*x + 82
     xcoeffs = [_x.coeffs[0] - _x.coeffs[1] * 9, _x.coeffs[1]]

--- a/py_ecc/optimized_bn128/optimized_curve.py
+++ b/py_ecc/optimized_bn128/optimized_curve.py
@@ -142,8 +142,6 @@ w = FQ12([0, 1] + [0] * 10)
 
 # Convert P => -P
 def neg(pt: Optimized_Point3D[Optimized_Field]) -> Optimized_Point3D[Optimized_Field]:
-    if is_inf(pt):
-        return pt
     x, y, z = pt
     return (x, -y, z)
 

--- a/tests/test_bn128_and_bls12_381.py
+++ b/tests/test_bn128_and_bls12_381.py
@@ -182,7 +182,8 @@ def test_Z1_object(add, eq, double, FQ, G1, multiply, neg, twist, Z1):
     assert eq(Z1, multiply(Z1, 1))
     assert eq(Z1, multiply(Z1, 2))
     assert eq(Z1, multiply(Z1, 3))
-    assert eq(Z1, neg(Z1))
+    # the 'is' test makes sure that neg is optimized for infinity by returning the same point
+    assert Z1 is neg(Z1)
     assert eq(Z1, twist(Z1))
 
 
@@ -193,7 +194,8 @@ def test_Z2_object(add, eq, double, FQ2, G2, multiply, neg, twist, Z2):
     assert eq(Z2, multiply(Z2, 1))
     assert eq(Z2, multiply(Z2, 2))
     assert eq(Z2, multiply(Z2, 3))
-    assert eq(Z2, neg(Z2))
+    # the 'is' test makes sure that neg is optimized for infinity by returning the same point
+    assert Z2 is neg(Z2)
     assert eq(Z2, twist(Z2))
 
 

--- a/tests/test_bn128_and_bls12_381.py
+++ b/tests/test_bn128_and_bls12_381.py
@@ -175,7 +175,7 @@ def test_G12_object(G12, b12, eq, add, double, multiply, is_on_curve, is_inf, cu
     assert is_inf(multiply(G12, curve_order))
 
 
-def test_Z1_object(add, eq, double, FQ, G1, multiply, neg, twist, Z1):
+def test_Z1_object(add, eq, double, FQ, G1, is_inf, multiply, neg, twist, Z1):
     assert eq(G1, add(G1, Z1))
     assert eq(Z1, double(Z1))
     assert eq(Z1, multiply(Z1, 0))
@@ -184,10 +184,8 @@ def test_Z1_object(add, eq, double, FQ, G1, multiply, neg, twist, Z1):
     assert eq(Z1, multiply(Z1, 3))
     # the 'is' test makes sure that neg is optimized for infinity by returning the same point
     assert Z1 is neg(Z1)
-    assert eq(Z1, twist(Z1))
 
-
-def test_Z2_object(add, eq, double, FQ2, G2, multiply, neg, twist, Z2):
+def test_Z2_object(add, eq, double, FQ2, G2, is_inf, multiply, neg, twist, Z2):
     assert eq(G2, add(G2, Z2))
     assert eq(Z2, double(Z2))
     assert eq(Z2, multiply(Z2, 0))
@@ -196,7 +194,15 @@ def test_Z2_object(add, eq, double, FQ2, G2, multiply, neg, twist, Z2):
     assert eq(Z2, multiply(Z2, 3))
     # the 'is' test makes sure that neg is optimized for infinity by returning the same point
     assert Z2 is neg(Z2)
-    assert eq(Z2, twist(Z2))
+    assert is_inf(twist(Z2))
+
+def test_none_point(lib, neg, twist):
+    if lib not in [optimized_bn128, optimized_bls12_381]:
+        pytest.skip()
+    with pytest.raises(Exception):
+        neg(None)
+    with pytest.raises(Exception):
+        twist(None)
 
 
 def test_pairing_negative_G1(pairing, G1, G2, FQ12, curve_order, multiply, neg):

--- a/tests/test_bn128_and_bls12_381.py
+++ b/tests/test_bn128_and_bls12_381.py
@@ -182,8 +182,7 @@ def test_Z1_object(add, eq, double, FQ, G1, is_inf, multiply, neg, twist, Z1):
     assert eq(Z1, multiply(Z1, 1))
     assert eq(Z1, multiply(Z1, 2))
     assert eq(Z1, multiply(Z1, 3))
-    # the 'is' test makes sure that neg is optimized for infinity by returning the same point
-    assert Z1 is neg(Z1)
+    assert is_inf(neg(Z1))
 
 def test_Z2_object(add, eq, double, FQ2, G2, is_inf, multiply, neg, twist, Z2):
     assert eq(G2, add(G2, Z2))
@@ -192,8 +191,7 @@ def test_Z2_object(add, eq, double, FQ2, G2, is_inf, multiply, neg, twist, Z2):
     assert eq(Z2, multiply(Z2, 1))
     assert eq(Z2, multiply(Z2, 2))
     assert eq(Z2, multiply(Z2, 3))
-    # the 'is' test makes sure that neg is optimized for infinity by returning the same point
-    assert Z2 is neg(Z2)
+    assert is_inf(neg(Z2))
     assert is_inf(twist(Z2))
 
 def test_none_point(lib, neg, twist):

--- a/tests/test_bn128_and_bls12_381.py
+++ b/tests/test_bn128_and_bls12_381.py
@@ -45,6 +45,16 @@ def G12(lib):
 
 
 @pytest.fixture
+def Z1(lib):
+    return lib.Z1
+
+
+@pytest.fixture
+def Z2(lib):
+    return lib.Z2
+
+
+@pytest.fixture
 def b(lib):
     return lib.b
 
@@ -104,6 +114,11 @@ def neg(lib):
     return lib.neg
 
 
+@pytest.fixture
+def twist(lib):
+    return lib.twist
+
+
 def test_FQ_object(FQ, field_modulus):
     assert FQ(2) * FQ(2) == FQ(4)
     assert FQ(2) / FQ(7) + FQ(9) / FQ(7) == FQ(11) / FQ(7)
@@ -158,6 +173,28 @@ def test_G12_object(G12, b12, eq, add, double, multiply, is_on_curve, is_inf, cu
     assert eq(add(multiply(G12, 9), multiply(G12, 5)), add(multiply(G12, 12), multiply(G12, 2)))
     assert is_on_curve(multiply(G12, 9), b12)
     assert is_inf(multiply(G12, curve_order))
+
+
+def test_Z1_object(add, eq, double, FQ, G1, multiply, neg, twist, Z1):
+    assert eq(G1, add(G1, Z1))
+    assert eq(Z1, double(Z1))
+    assert eq(Z1, multiply(Z1, 0))
+    assert eq(Z1, multiply(Z1, 1))
+    assert eq(Z1, multiply(Z1, 2))
+    assert eq(Z1, multiply(Z1, 3))
+    assert eq(Z1, neg(Z1))
+    assert eq(Z1, twist(Z1))
+
+
+def test_Z2_object(add, eq, double, FQ2, G2, multiply, neg, twist, Z2):
+    assert eq(G2, add(G2, Z2))
+    assert eq(Z2, double(Z2))
+    assert eq(Z2, multiply(Z2, 0))
+    assert eq(Z2, multiply(Z2, 1))
+    assert eq(Z2, multiply(Z2, 2))
+    assert eq(Z2, multiply(Z2, 3))
+    assert eq(Z2, neg(Z2))
+    assert eq(Z2, twist(Z2))
 
 
 def test_pairing_negative_G1(pairing, G1, G2, FQ12, curve_order, multiply, neg):


### PR DESCRIPTION
### What was wrong?
The unoptimized elliptic curve point at infinity is represented by None.
The optimized elliptic curve point at infinity is represented by (x, y, 0)

There are a few functions in the optimized curve library that incorrectly check for infinity with a null check.
### How was it fixed?
The null checks are replaced with `is_inf` checks.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://metrouk2.files.wordpress.com/2013/07/gh2.jpg)
