### PR TITLE
Fix mismatched testing dependency versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ from setuptools import setup, find_packages
 
 extras_require = {
     'test': [
-        "pytest==3.2.2",
-        "pytest-xdist"
+        "pytest==3.10.1",
+        "pytest-xdist==1.26.0"
     ],
     'lint': [
         "flake8==3.4.1",


### PR DESCRIPTION
### What was wrong?
Tests are failing with:
```
pkg_resources.VersionConflict: (pytest 3.2.2 (/home/circleci/repo/.tox/py35-core/lib/python3.5/site-packages), Requirement.parse('pytest>=3.6.0'))
```


### How was it fixed?
`pytest` has been upgraded to the latest v3 release
`pytest-xdist` has been given an explicit version requirement

Alternatively,  #41 addresses the `pytest` upgrade.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://tailandfur.com/wp-content/uploads/2014/04/Animal-showing-tongue-32.jpg)
