### PR TITLE
Fix #59, add fields to optimized_bn128.__init__

### DIFF
--- a/py_ecc/optimized_bn128/__init__.py
+++ b/py_ecc/optimized_bn128/__init__.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import
 
+from py_ecc.fields import (  # noqa: F401
+    optimized_bn128_FQ as FQ,
+    optimized_bn128_FQP as FQP,
+    optimized_bn128_FQ2 as FQ2,
+    optimized_bn128_FQ12 as FQ12,
+)
 from .optimized_field_elements import (  # noqa: F401
     field_modulus,
-    FQ,
-    FQP,
-    FQ2,
-    FQ12,
 )
 from .optimized_curve import (  # noqa: F401
     add,


### PR DESCRIPTION
### What was wrong?

#59

### How was it fixed?

This makes py-evm tests happy

#### Cute Animal Picture

<a title="(c) Programa de Conservación Ex-situ del Lince Ibérico  www.lynxexsitu.es [CC BY 3.0 es (https://creativecommons.org/licenses/by/3.0/es/deed.en)], via Wikimedia Commons" href="https://commons.wikimedia.org/wiki/File:Linces1.jpg"><img width="256" alt="Linces1" src="https://upload.wikimedia.org/wikipedia/commons/c/cf/Linces1.jpg"></a>