### PR TITLE
Remove the curve_name from the fields API

### DIFF
--- a/py_ecc/fields/__init__.py
+++ b/py_ecc/fields/__init__.py
@@ -17,128 +17,86 @@ from .optimized_field_elements import (
 )
 
 
-# Create seperate classes for all Fields for each curve
+#
+# bn128 curve fields
+#
+class bn128_FQ(FQ):
+    field_modulus = field_properties["bn128"]["field_modulus"]
 
-bn128_FQ = type(
-    "bn128_FQ",
-    (FQ,),
-    {
-        'field_modulus': field_properties["bn128"]["field_modulus"],
-    }
-)
-bn128_FQP = type(
-    "bn128_FQP",
-    (FQP,),
-    {
-        'field_modulus': field_properties["bn128"]["field_modulus"],
-    }
-)
-bn128_FQ2 = type(
-    "bn128_FQ2",
-    (FQ2,),
-    {
-        'field_modulus': field_properties["bn128"]["field_modulus"],
-        'FQ2_MODULUS_COEFFS': field_properties["bn128"]["fq2_modulus_coeffs"],
-    }
-)
-bn128_FQ12 = type(
-    "bn128_FQ12",
-    (FQ12,),
-    {
-        'field_modulus': field_properties["bn128"]["field_modulus"],
-        'FQ12_MODULUS_COEFFS': field_properties["bn128"]["fq12_modulus_coeffs"],
-    }
-)
 
-bls12_381_FQ = type(
-    "bls12_381_FQ",
-    (FQ,),
-    {
-        'field_modulus': field_properties["bls12_381"]["field_modulus"],
-    }
-)
-bls12_381_FQP = type(
-    "bls12_381_FQP",
-    (FQP,),
-    {
-        'field_modulus': field_properties["bls12_381"]["field_modulus"],
-    }
-)
-bls12_381_FQ2 = type(
-    "bls12_381_FQ2",
-    (FQ2,),
-    {
-        'field_modulus': field_properties["bls12_381"]["field_modulus"],
-        'FQ2_MODULUS_COEFFS': field_properties["bls12_381"]["fq2_modulus_coeffs"],
-    }
-)
-bls12_381_FQ12 = type(
-    "bls12_381_FQ12",
-    (FQ12,),
-    {
-        'field_modulus': field_properties["bls12_381"]["field_modulus"],
-        'FQ12_MODULUS_COEFFS': field_properties["bls12_381"]["fq12_modulus_coeffs"],
-    }
-)
+class bn128_FQP(FQP):
+    field_modulus = field_properties["bn128"]["field_modulus"]
 
-optimized_bn128_FQ = type(
-    "optimized_bn128_FQ",
-    (optimized_FQ,),
-    {
-        'field_modulus': field_properties["bn128"]["field_modulus"],
-    }
-)
-optimized_bn128_FQP = type(
-    "optimized_bn128_FQP",
-    (optimized_FQP,),
-    {
-        'field_modulus': field_properties["bn128"]["field_modulus"],
-    }
-)
-optimized_bn128_FQ2 = type(
-    "optimized_bn128_FQ2",
-    (optimized_FQ2,),
-    {
-        'field_modulus': field_properties["bn128"]["field_modulus"],
-        'FQ2_MODULUS_COEFFS': field_properties["bn128"]["fq2_modulus_coeffs"],
-    }
-)
-optimized_bn128_FQ12 = type(
-    "optimized_bn128_FQ12",
-    (optimized_FQ12,),
-    {
-        'field_modulus': field_properties["bn128"]["field_modulus"],
-        'FQ12_MODULUS_COEFFS': field_properties["bn128"]["fq12_modulus_coeffs"],
-    }
-)
 
-optimized_bls12_381_FQ = type(
-    "optimized_bls12_381_FQ",
-    (optimized_FQ,),
-    {
-        'field_modulus': field_properties["bls12_381"]["field_modulus"],
-    }
-)
-optimized_bls12_381_FQP = type(
-    "optimized_bls12_381_FQP",
-    (optimized_FQP,),
-    {
-        'field_modulus': field_properties["bls12_381"]["field_modulus"],
-    }
-)
-optimized_bls12_381_FQ2 = type(
-    "optimized_bls12_381_FQ2",
-    (optimized_FQ2,),
-    {
-        'field_modulus': field_properties["bls12_381"]["field_modulus"],
-        'FQ2_MODULUS_COEFFS': field_properties["bls12_381"]["fq2_modulus_coeffs"],
-    }
-)
-optimized_bls12_381_FQ12 = type(
-    "optimized_bls12_381_FQ12",
-    (optimized_FQ12,),
-    {
-        'field_modulus': field_properties["bls12_381"]["field_modulus"],
-        'FQ12_MODULUS_COEFFS': field_properties["bls12_381"]["fq12_modulus_coeffs"],
-    }
-)
+class bn128_FQ2(FQ2):
+    field_modulus = field_properties["bn128"]["field_modulus"]
+    FQ2_MODULUS_COEFFS = field_properties["bn128"]["fq2_modulus_coeffs"]
+
+
+class bn128_FQ12(FQ12):
+    field_modulus = field_properties["bn128"]["field_modulus"]
+    FQ12_MODULUS_COEFFS = field_properties["bn128"]["fq12_modulus_coeffs"]
+
+
+#
+# bls12_381 curve fields
+#
+class bls12_381_FQ(FQ):
+    field_modulus = field_properties["bls12_381"]["field_modulus"]
+
+
+class bls12_381_FQP(FQP):
+    field_modulus = field_properties["bls12_381"]["field_modulus"]
+
+
+class bls12_381_FQ2(FQ2):
+    field_modulus = field_properties["bls12_381"]["field_modulus"]
+    FQ2_MODULUS_COEFFS = field_properties["bls12_381"]["fq2_modulus_coeffs"]
+
+
+class bls12_381_FQ12(FQ12):
+    field_modulus = field_properties["bls12_381"]["field_modulus"]
+    FQ12_MODULUS_COEFFS = field_properties["bls12_381"]["fq12_modulus_coeffs"]
+
+
+#
+# optimized_bn128 curve fields
+#
+
+class optimized_bn128_FQ(optimized_FQ):
+    field_modulus = field_properties["bn128"]["field_modulus"]
+
+
+class optimized_bn128_FQP(optimized_FQP):
+    field_modulus = field_properties["bn128"]["field_modulus"]
+
+
+class optimized_bn128_FQ2(optimized_FQ2):
+    field_modulus = field_properties["bn128"]["field_modulus"]
+    FQ2_MODULUS_COEFFS = field_properties["bn128"]["fq2_modulus_coeffs"]
+
+
+class optimized_bn128_FQ12(optimized_FQ12):
+    field_modulus = field_properties["bn128"]["field_modulus"]
+    FQ12_MODULUS_COEFFS = field_properties["bn128"]["fq12_modulus_coeffs"]
+
+
+#
+# optimized_bls12_381 curve fields
+#
+class optimized_bls12_381_FQ(optimized_FQ):
+    field_modulus = field_properties["bls12_381"]["field_modulus"]
+
+
+class optimized_bls12_381_FQP(optimized_FQP):
+    field_modulus = field_properties["bls12_381"]["field_modulus"]
+
+
+class optimized_bls12_381_FQ2(optimized_FQ2):
+    field_modulus = field_properties["bls12_381"]["field_modulus"]
+    FQ2_MODULUS_COEFFS = field_properties["bls12_381"]["fq2_modulus_coeffs"]
+
+
+class optimized_bls12_381_FQ12(optimized_FQ12):
+    field_modulus = field_properties["bls12_381"]["field_modulus"]
+    FQ12_MODULUS_COEFFS = field_properties["bls12_381"]["fq12_modulus_coeffs"]

--- a/py_ecc/fields/__init__.py
+++ b/py_ecc/fields/__init__.py
@@ -23,7 +23,6 @@ bn128_FQ = type(
     "bn128_FQ",
     (FQ,),
     {
-        'curve_name': "bn128",
         'field_modulus': field_properties["bn128"]["field_modulus"],
     }
 )
@@ -31,7 +30,6 @@ bn128_FQP = type(
     "bn128_FQP",
     (FQP,),
     {
-        'curve_name': "bn128",
         'field_modulus': field_properties["bn128"]["field_modulus"],
     }
 )
@@ -39,7 +37,6 @@ bn128_FQ2 = type(
     "bn128_FQ2",
     (FQ2,),
     {
-        'curve_name': "bn128",
         'field_modulus': field_properties["bn128"]["field_modulus"],
         'FQ2_MODULUS_COEFFS': field_properties["bn128"]["fq2_modulus_coeffs"],
     }
@@ -48,7 +45,6 @@ bn128_FQ12 = type(
     "bn128_FQ12",
     (FQ12,),
     {
-        'curve_name': "bn128",
         'field_modulus': field_properties["bn128"]["field_modulus"],
         'FQ12_MODULUS_COEFFS': field_properties["bn128"]["fq12_modulus_coeffs"],
     }
@@ -58,7 +54,6 @@ bls12_381_FQ = type(
     "bls12_381_FQ",
     (FQ,),
     {
-        'curve_name': "bls12_381",
         'field_modulus': field_properties["bls12_381"]["field_modulus"],
     }
 )
@@ -66,7 +61,6 @@ bls12_381_FQP = type(
     "bls12_381_FQP",
     (FQP,),
     {
-        'curve_name': "bls12_381",
         'field_modulus': field_properties["bls12_381"]["field_modulus"],
     }
 )
@@ -74,7 +68,6 @@ bls12_381_FQ2 = type(
     "bls12_381_FQ2",
     (FQ2,),
     {
-        'curve_name': "bls12_381",
         'field_modulus': field_properties["bls12_381"]["field_modulus"],
         'FQ2_MODULUS_COEFFS': field_properties["bls12_381"]["fq2_modulus_coeffs"],
     }
@@ -83,7 +76,6 @@ bls12_381_FQ12 = type(
     "bls12_381_FQ12",
     (FQ12,),
     {
-        'curve_name': "bls12_381",
         'field_modulus': field_properties["bls12_381"]["field_modulus"],
         'FQ12_MODULUS_COEFFS': field_properties["bls12_381"]["fq12_modulus_coeffs"],
     }
@@ -93,7 +85,6 @@ optimized_bn128_FQ = type(
     "optimized_bn128_FQ",
     (optimized_FQ,),
     {
-        'curve_name': "bn128",
         'field_modulus': field_properties["bn128"]["field_modulus"],
     }
 )
@@ -101,7 +92,6 @@ optimized_bn128_FQP = type(
     "optimized_bn128_FQP",
     (optimized_FQP,),
     {
-        'curve_name': "bn128",
         'field_modulus': field_properties["bn128"]["field_modulus"],
     }
 )
@@ -109,7 +99,6 @@ optimized_bn128_FQ2 = type(
     "optimized_bn128_FQ2",
     (optimized_FQ2,),
     {
-        'curve_name': "bn128",
         'field_modulus': field_properties["bn128"]["field_modulus"],
         'FQ2_MODULUS_COEFFS': field_properties["bn128"]["fq2_modulus_coeffs"],
     }
@@ -118,7 +107,6 @@ optimized_bn128_FQ12 = type(
     "optimized_bn128_FQ12",
     (optimized_FQ12,),
     {
-        'curve_name': "bn128",
         'field_modulus': field_properties["bn128"]["field_modulus"],
         'FQ12_MODULUS_COEFFS': field_properties["bn128"]["fq12_modulus_coeffs"],
     }
@@ -128,7 +116,6 @@ optimized_bls12_381_FQ = type(
     "optimized_bls12_381_FQ",
     (optimized_FQ,),
     {
-        'curve_name': "bls12_381",
         'field_modulus': field_properties["bls12_381"]["field_modulus"],
     }
 )
@@ -136,7 +123,6 @@ optimized_bls12_381_FQP = type(
     "optimized_bls12_381_FQP",
     (optimized_FQP,),
     {
-        'curve_name': "bls12_381",
         'field_modulus': field_properties["bls12_381"]["field_modulus"],
     }
 )
@@ -144,7 +130,6 @@ optimized_bls12_381_FQ2 = type(
     "optimized_bls12_381_FQ2",
     (optimized_FQ2,),
     {
-        'curve_name': "bls12_381",
         'field_modulus': field_properties["bls12_381"]["field_modulus"],
         'FQ2_MODULUS_COEFFS': field_properties["bls12_381"]["fq2_modulus_coeffs"],
     }
@@ -153,7 +138,6 @@ optimized_bls12_381_FQ12 = type(
     "optimized_bls12_381_FQ12",
     (optimized_FQ12,),
     {
-        'curve_name': "bls12_381",
         'field_modulus': field_properties["bls12_381"]["field_modulus"],
         'FQ12_MODULUS_COEFFS': field_properties["bls12_381"]["fq12_modulus_coeffs"],
     }

--- a/py_ecc/fields/field_elements.py
+++ b/py_ecc/fields/field_elements.py
@@ -22,14 +22,8 @@ class FQ(object):
     """
     n = None  # type: int
     field_modulus = None
-    # curve_name can be either 'bn128' or 'bls12_381'
-    # This is needed to obtain field_modulus, FQ2_MODULUS_COEFFS
-    # and FQ12_MODULUS_COEFFS from the curve properties
-    curve_name = None
 
     def __init__(self, val: IntOrFQ) -> None:
-        if self.curve_name is None:
-            raise AttributeError("Curve Name hasn't been specified")
         if self.field_modulus is None:
             raise AttributeError("Field Modulus hasn't been specified")
 
@@ -187,14 +181,11 @@ class FQP(object):
     A class for elements in polynomial extension fields
     """
     degree = 0
-    curve_name = None
     field_modulus = None
 
     def __init__(self,
                  coeffs: Sequence[IntOrFQ],
                  modulus_coeffs: Sequence[IntOrFQ]=None) -> None:
-        if self.curve_name is None:
-            raise AttributeError("Curve Name hasn't been specified")
         if self.field_modulus is None:
             raise AttributeError("Field Modulus hasn't been specified")
 
@@ -202,11 +193,11 @@ class FQP(object):
             raise Exception(
                 "coeffs and modulus_coeffs aren't of the same length"
             )
-        # Encoding all coefficients in type FQ (in regards to the curve name too)
+        # Encoding all coefficients in the corresponding type FQ
         self.FQP_corresponding_FQ_class = type(
-            "FQP_corresponding_FQ_class_" + self.curve_name,
+            "FQP_corresponding_FQ_class",
             (FQ,),
-            {'curve_name': self.curve_name, 'field_modulus': self.field_modulus}
+            {'field_modulus': self.field_modulus}
         )
         self.coeffs = tuple(self.FQP_corresponding_FQ_class(c) for c in coeffs)
         # The coefficients of the modulus, without the leading [1]
@@ -353,8 +344,6 @@ class FQ2(FQP):
     FQ2_MODULUS_COEFFS = None
 
     def __init__(self, coeffs: Sequence[IntOrFQ]) -> None:
-        if self.curve_name is None:
-            raise AttributeError("Curve Name hasn't been specified")
         if self.FQ2_MODULUS_COEFFS is None:
             raise AttributeError("FQ2 Modulus Coeffs haven't been specified")
 
@@ -369,8 +358,6 @@ class FQ12(FQP):
     FQ12_MODULUS_COEFFS = None
 
     def __init__(self, coeffs: Sequence[IntOrFQ]) -> None:
-        if self.curve_name is None:
-            raise AttributeError("Curve Name hasn't been specified")
         if self.FQ12_MODULUS_COEFFS is None:
             raise AttributeError("FQ12 Modulus Coeffs haven't been specified")
 

--- a/py_ecc/fields/optimized_field_elements.py
+++ b/py_ecc/fields/optimized_field_elements.py
@@ -22,14 +22,8 @@ class FQ(object):
     """
     n = None  # type: int
     field_modulus = None
-    # curve_name can be either 'bn128' or 'bls12_381'
-    # This is needed to obtain field_modulus, FQ2_MODULUS_COEFFS
-    # and FQ12_MODULUS_COEFFS from the curve properties
-    curve_name = None
 
     def __init__(self, val: IntOrFQ) -> None:
-        if self.curve_name is None:
-            raise AttributeError("Curve Name hasn't been specified")
         if self.field_modulus is None:
             raise AttributeError("Field Modulus hasn't been specified")
 
@@ -187,15 +181,12 @@ class FQP(object):
     A class for elements in polynomial extension fields
     """
     degree = 0  # type: int
-    mc_tuples = None  # type: List[Tuple[int, int]]
-    curve_name = None
     field_modulus = None
+    mc_tuples = None  # type: List[Tuple[int, int]]
 
     def __init__(self,
                  coeffs: Sequence[IntOrFQ],
                  modulus_coeffs: Sequence[IntOrFQ]=None) -> None:
-        if self.curve_name is None:
-            raise AttributeError("Curve Name hasn't been specified")
         if self.field_modulus is None:
             raise AttributeError("Field Modulus hasn't been specified")
 
@@ -372,8 +363,6 @@ class FQ2(FQP):
     FQ2_MODULUS_COEFFS = None
 
     def __init__(self, coeffs: Sequence[IntOrFQ]) -> None:
-        if self.curve_name is None:
-            raise AttributeError("Curve Name hasn't been specified")
         if self.FQ2_MODULUS_COEFFS is None:
             raise AttributeError("FQ2 Modulus Coeffs haven't been specified")
 
@@ -389,8 +378,6 @@ class FQ12(FQP):
     FQ12_MODULUS_COEFFS = None
 
     def __init__(self, coeffs: Sequence[IntOrFQ]) -> None:
-        if self.curve_name is None:
-            raise AttributeError("Curve Name hasn't been specified")
         if self.FQ12_MODULUS_COEFFS is None:
             raise AttributeError("FQ12 Modulus Coeffs haven't been specified")
 


### PR DESCRIPTION
### What was wrong?
In the `__init__.py` of the `fields API` the classes have been declared using `type`. This has to be replaced with the actual class definitions.


### How was it fixed?
Replace the `type` with `class` in the `__init__.py`.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.wonderslist.com/wp-content/uploads/2016/11/Arctic-Foxes-Cute-Animal.jpg)
