### PR TITLE
Use SHA-256 instead of Keccak256

### DIFF
--- a/py_ecc/bls/hash.py
+++ b/py_ecc/bls/hash.py
@@ -1,12 +1,17 @@
-from eth_typing import Hash32
-from eth_hash.auto import keccak
+import hashlib
 from typing import Union
+
+from eth_typing import Hash32
 
 
 def hash_eth2(data: Union[bytes, bytearray]) -> Hash32:
     """
-    Return Keccak-256 hashed result.
+    Return SHA-256 hashed result.
+
+    Note: this API is currently under active research/development so is subject to change
+    without a major version bump.
+
     Note: it's a placeholder and we aim to migrate to a S[T/N]ARK-friendly hash function in
     a future Ethereum 2.0 deployment phase.
     """
-    return Hash32(keccak(data))
+    return Hash32(hashlib.sha256(data).digest())

--- a/py_ecc/bls/utils.py
+++ b/py_ecc/bls/utils.py
@@ -147,7 +147,7 @@ def G1_to_pubkey(pt: G1Uncompressed) -> BLSPubkey:
 
 def pubkey_to_G1(pubkey: BLSPubkey) -> G1Uncompressed:
     z = big_endian_to_int(pubkey)
-    return decompress_G1(z)
+    return decompress_G1(G1Compressed(z))
 
 #
 # G2

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
     packages=find_packages(exclude=('tests', 'docs')),
     package_data={'py_ecc': ['py.typed']},
     install_requires=[
-        "eth-hash[pycryptodome]",
         "eth-typing>=2.1.0,<3.0.0",
         "eth-utils>=1.3.0,<2",
         "mypy-extensions>=0.4.1",


### PR DESCRIPTION
### What was wrong?

Fixes #68.

Updates the hash function so we can generate correct BLS tests in the eth2.0 specs/tests repo.

### How was it fixed?

Use the stdlib's SHA-256 instead of the Keccak256 import.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://4.bp.blogspot.com/-_vTDmo_fSTw/T3YTV0AfGiI/AAAAAAAAAX4/Zjh2HaoU5Zo/s1600/beautiful+kitten.jpg)
