### PR TITLE
IETF interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,36 +15,32 @@ pip install py_ecc
 ```python
 from py_ecc import bls
 
-domain = 43
-
 private_key = 5566
-public_key = bls.privtopub(private_key)
+public_key = bls.PrivToPub(private_key)
 
 # Hash your message to 32 bytes
 message_hash = b'\xab' * 32
 
 # Signing
-signature = bls.sign(message_hash, private_key, domain)
+signature = bls.Sign(message_hash, private_key)
 
 # Verifying
-assert bls.verify(message_hash, public_key, signature, domain)
+assert bls.Verify(message_hash, public_key, signature)
 ```
-
-Think of a `domain` as a version. Signing and verifying would not work on different domains. Setting a new domain in an upgraded system prevents it from being affected by the old messages and signatures.
 
 ### Aggregating Signatures and Public Keys
 
 ```python
 private_keys = [3, 14, 159]
-public_keys = [bls.privtopub(key) for key in private_keys]
-signatures = [bls.sign(message_hash, key, domain) for key in private_keys]
+public_keys = [bls.PrivToPub(key) for key in private_keys]
+signatures = [bls.Sign(message_hash, key) for key in private_keys]
 
 # Aggregating
-agg_sig = bls.aggregate_signatures(signatures)
-agg_pub = bls.aggregate_pubkeys(public_keys)
+agg_sig = bls.AggregateSignatures(signatures)
+agg_pub = bls.AggregatePubkeys(public_keys)
 
 # Verifying
-assert bls.verify(message_hash, agg_pub, agg_sig, domain)
+assert bls.Verify(message_hash, agg_pub, agg_sig)
 ```
 
 ### Multiple Aggregation
@@ -54,9 +50,9 @@ message_hash_1, message_hash_2 = b'\xaa' * 32, b'\xbb' * 32
 
 msg_hashes = [message_hash_1, message_hash_2]
 agg_pubs = [agg_pub_1, agg_pub_2]
-agg_agg_sig = bls.aggregate_signatures([agg_sig_1, agg_sig_2])
+agg_agg_sig = bls.AggregateSignatures([agg_sig_1, agg_sig_2])
 
-assert bls.verify_multiple(agg_pubs, msg_hashes, agg_agg_sig, domain)
+assert bls.VerifyMultiple(agg_pubs, msg_hashes, agg_agg_sig)
 ```
 
 ## Developer Setup

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ public_keys = [bls.PrivToPub(key) for key in private_keys]
 signatures = [bls.Sign(message_hash, key) for key in private_keys]
 
 # Aggregating
-agg_sig = bls.AggregateSignatures(signatures)
-agg_pub = bls.AggregatePubkeys(public_keys)
+agg_sig = bls.Aggregate(signatures)
+agg_pub = bls.AggregatePubkeys(*public_keys)
 
 # Verifying
 assert bls.Verify(message_hash, agg_pub, agg_sig)
@@ -50,7 +50,7 @@ message_hash_1, message_hash_2 = b'\xaa' * 32, b'\xbb' * 32
 
 msg_hashes = [message_hash_1, message_hash_2]
 agg_pubs = [agg_pub_1, agg_pub_2]
-agg_agg_sig = bls.AggregateSignatures([agg_sig_1, agg_sig_2])
+agg_agg_sig = bls.Aggregate([agg_sig_1, agg_sig_2])
 
 assert bls.VerifyMultiple(agg_pubs, msg_hashes, agg_agg_sig)
 ```

--- a/py_ecc/bls/__init__.py
+++ b/py_ecc/bls/__init__.py
@@ -1,8 +1,9 @@
 from .api import (  # noqa: F401
-    aggregate_pubkeys,
-    aggregate_signatures,
-    privtopub,
-    sign,
-    verify,
-    aggregate_verify,
+    AggregatePubkeys,
+    AggregateSignatures,
+    PrivToPub,
+    Sign,
+    Verify,
+    AggregateVerify,
+    FastAggregateVerify,
 )

--- a/py_ecc/bls/__init__.py
+++ b/py_ecc/bls/__init__.py
@@ -2,6 +2,7 @@ from .api import (  # noqa: F401
     AggregatePubkeys,
     AggregateSignatures,
     PrivToPub,
+    KeyGen,
     Sign,
     Verify,
     AggregateVerify,

--- a/py_ecc/bls/__init__.py
+++ b/py_ecc/bls/__init__.py
@@ -4,5 +4,5 @@ from .api import (  # noqa: F401
     privtopub,
     sign,
     verify,
-    verify_multiple,
+    aggregate_verify,
 )

--- a/py_ecc/bls/__init__.py
+++ b/py_ecc/bls/__init__.py
@@ -1,6 +1,6 @@
 from .api import (  # noqa: F401
     AggregatePubkeys,
-    AggregateSignatures,
+    Aggregate,
     PrivToPub,
     KeyGen,
     Sign,

--- a/py_ecc/bls/api.py
+++ b/py_ecc/bls/api.py
@@ -34,7 +34,7 @@ from .utils import (
 )
 
 
-def sign(sk: int, message: bytes) -> BLSSignature:
+def Sign(sk: int, message: bytes) -> BLSSignature:
     return G2_to_signature(
         multiply(
             hash_to_G2(message),
@@ -42,11 +42,11 @@ def sign(sk: int, message: bytes) -> BLSSignature:
         ))
 
 
-def privtopub(k: int) -> BLSPubkey:
+def PrivToPub(k: int) -> BLSPubkey:
     return G1_to_pubkey(multiply(G1, k))
 
 
-def verify(pk: BLSPubkey,
+def Verify(pk: BLSPubkey,
            message: bytes,
            signature: BLSSignature) -> bool:
     signature_point = signature_to_G2(signature)
@@ -69,23 +69,23 @@ def verify(pk: BLSPubkey,
         return False
 
 
-def aggregate_signatures(signatures: Sequence[BLSSignature]) -> BLSSignature:
+def AggregateSignatures(signatures: Sequence[BLSSignature]) -> BLSSignature:
     o = Z2
     for s in signatures:
         o = add(o, signature_to_G2(s))
     return G2_to_signature(o)
 
 
-def aggregate_pubkeys(pks: Sequence[BLSPubkey]) -> BLSPubkey:
+def AggregatePubkeys(pks: Sequence[BLSPubkey]) -> BLSPubkey:
     o = Z1
     for p in pks:
         o = add(o, pubkey_to_G1(p))
     return G1_to_pubkey(o)
 
 
-def aggregate_verify(pks: Sequence[BLSPubkey],
-                     messages: Sequence[bytes],
-                     signature: BLSSignature) -> bool:
+def AggregateVerify(pks: Sequence[BLSPubkey],
+                    messages: Sequence[bytes],
+                    signature: BLSSignature) -> bool:
     len_msgs = len(messages)
 
     if len(pks) != len_msgs:
@@ -117,8 +117,8 @@ def aggregate_verify(pks: Sequence[BLSPubkey],
         return False
 
 
-def fast_aggregate_verify(pks: Sequence[BLSPubkey],
-                          message: bytes,
-                          signature: BLSSignature) -> bool:
-    aggregate_pubkey = aggregate_pubkeys(pks)
-    return verify(aggregate_pubkey, message, signature)
+def FastAggregateVerify(pks: Sequence[BLSPubkey],
+                        message: bytes,
+                        signature: BLSSignature) -> bool:
+    aggregate_pubkey = AggregatePubkeys(pks)
+    return Verify(aggregate_pubkey, message, signature)

--- a/py_ecc/bls/utils.py
+++ b/py_ecc/bls/utils.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from eth_typing import (
     BLSPubkey,
     BLSSignature,
@@ -50,7 +52,7 @@ from .typing import (
 #
 
 
-def modular_squareroot_in_FQ2(value: FQ2) -> FQ2:
+def modular_squareroot_in_FQ2(value: FQ2) -> Optional[FQ2]:
     """
     ``modular_squareroot_in_FQ2(x)`` returns the value ``y`` such that ``y**2 % q == x``,
     and None if this is not possible. In cases where there are two solutions,

--- a/py_ecc/bls/utils.py
+++ b/py_ecc/bls/utils.py
@@ -1,7 +1,6 @@
 from eth_typing import (
     BLSPubkey,
     BLSSignature,
-    Hash32,
 )
 from eth_utils import (
     big_endian_to_int,
@@ -70,7 +69,7 @@ def modular_squareroot_in_FQ2(value: FQ2) -> FQ2:
     return None
 
 
-def hash_to_G2(message_hash: Hash32) -> G2Uncompressed:
+def hash_to_G2(message: bytes) -> G2Uncompressed:
     """
     Convert a message to a point on G2 as defined here:
     https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-05#section-3
@@ -78,8 +77,8 @@ def hash_to_G2(message_hash: Hash32) -> G2Uncompressed:
     Contants and inputs follow the ciphersuite ``BLS12381G2-SHA256-SSWU-RO-`` defined here:
     https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-05#section-8.9.2
     """
-    u0 = hash_to_base_FQ2(message_hash, 0)
-    u1 = hash_to_base_FQ2(message_hash, 1)
+    u0 = hash_to_base_FQ2(message, 0)
+    u1 = hash_to_base_FQ2(message, 1)
     q0 = map_to_curve_G2(u0)
     q1 = map_to_curve_G2(u1)
     r = add(q0, q1)
@@ -87,14 +86,14 @@ def hash_to_G2(message_hash: Hash32) -> G2Uncompressed:
     return p
 
 
-def hash_to_base_FQ2(message_hash: Hash32, ctr: int) -> FQ2:
+def hash_to_base_FQ2(message: bytes, ctr: int) -> FQ2:
     """
     Hash To Base for FQ2
 
     Convert a message to a point in the finite field as defined here:
     https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-05#section-5
     """
-    m_prime = hkdf_extract(DST, message_hash + b'\x00')
+    m_prime = hkdf_extract(DST, message + b'\x00')
     info_pfx = b'H2C' + bytes([ctr])
     e = []
 

--- a/tests/test_bls.py
+++ b/tests/test_bls.py
@@ -7,6 +7,7 @@ from py_ecc.bls import (
     AggregatePubkeys,
     AggregateSignatures,
     PrivToPub,
+    KeyGen,
     Sign,
     Verify,
     AggregateVerify,
@@ -228,3 +229,16 @@ def test_fast_aggregate_verify(msg, privkeys):
         message=msg,
         signature=aggsig,
     )
+
+
+@pytest.mark.parametrize(
+    # Tests taken from https://eips.ethereum.org/EIPS/eip-2333
+    'ikm, privkey',
+    [
+        (bytes.fromhex('c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f001698e7463b04') , 12513733877922233913083619867448865075222526338446857121953625441395088009793),
+        (bytes.fromhex('0099FF991111002299DD7744EE3355BBDD8844115566CC55663355668888CC00'), 45379166311535261329029945990467475187325618028073620882733843918126031931161),
+    ]
+)
+def test_key_gen(ikm, privkey):
+    _, calc_privkey = KeyGen(ikm)
+    assert calc_privkey == privkey

--- a/tests/test_bls.py
+++ b/tests/test_bls.py
@@ -5,7 +5,7 @@ import pytest
 
 from py_ecc.bls import (
     AggregatePubkeys,
-    AggregateSignatures,
+    Aggregate,
     PrivToPub,
     KeyGen,
     Sign,
@@ -172,8 +172,8 @@ def test_bls_core(privkey):
 def test_signature_aggregation(msg, privkeys):
     sigs = [Sign(k, msg) for k in privkeys]
     pubs = [PrivToPub(k) for k in privkeys]
-    aggsig = AggregateSignatures(sigs)
-    aggpub = AggregatePubkeys(pubs)
+    aggsig = Aggregate(*sigs)
+    aggpub = AggregatePubkeys(*pubs)
     assert Verify(aggpub, msg, aggsig)
 
 
@@ -194,23 +194,19 @@ def test_signature_aggregation(msg, privkeys):
 def test_multi_aggregation(msg_1, msg_2, privkeys_1, privkeys_2):
     sigs_1 = [Sign(k, msg_1) for k in privkeys_1]
     pubs_1 = [PrivToPub(k) for k in privkeys_1]
-    aggsig_1 = AggregateSignatures(sigs_1)
-    aggpub_1 = AggregatePubkeys(pubs_1)
+    aggsig_1 = Aggregate(*sigs_1)
+    aggpub_1 = AggregatePubkeys(*pubs_1)
 
     sigs_2 = [Sign(k, msg_2) for k in privkeys_2]
     pubs_2 = [PrivToPub(k) for k in privkeys_2]
-    aggsig_2 = AggregateSignatures(sigs_2)
-    aggpub_2 = AggregatePubkeys(pubs_2)
+    aggsig_2 = Aggregate(*sigs_2)
+    aggpub_2 = AggregatePubkeys(*pubs_2)
 
     messages = [msg_1, msg_2]
     pubs = [aggpub_1, aggpub_2]
-    aggsig = AggregateSignatures([aggsig_1, aggsig_2])
+    aggsig = Aggregate(*[aggsig_1, aggsig_2])
 
-    assert AggregateVerify(
-        pks=pubs,
-        messages=messages,
-        signature=aggsig,
-    )
+    assert AggregateVerify(list(zip(pubs, messages)), aggsig)
 
 
 @pytest.mark.parametrize(
@@ -223,12 +219,8 @@ def test_multi_aggregation(msg_1, msg_2, privkeys_1, privkeys_2):
 def test_fast_aggregate_verify(msg, privkeys):
     sigs = [Sign(sk, msg) for sk in privkeys]
     pubs = [PrivToPub(sk) for sk in privkeys]
-    aggsig = AggregateSignatures(sigs)
-    assert FastAggregateVerify(
-        pks=pubs,
-        message=msg,
-        signature=aggsig,
-    )
+    aggsig = Aggregate(*sigs)
+    assert FastAggregateVerify(*pubs, msg, aggsig)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_bls.py
+++ b/tests/test_bls.py
@@ -4,12 +4,12 @@ from eth_utils import (
 import pytest
 
 from py_ecc.bls import (
-    aggregate_pubkeys,
-    aggregate_signatures,
-    privtopub,
-    sign,
-    verify,
-    aggregate_verify,
+    AggregatePubkeys,
+    AggregateSignatures,
+    PrivToPub,
+    Sign,
+    Verify,
+    AggregateVerify,
 )
 from py_ecc.bls.utils import (
     compress_G1,
@@ -155,9 +155,9 @@ def test_bls_core(privkey):
     assert normalize(decompress_G1(compress_G1(p1))) == normalize(p1)
     assert normalize(decompress_G2(compress_G2(p2))) == normalize(p2)
     assert normalize(decompress_G2(compress_G2(msghash))) == normalize(msghash)
-    sig = sign(privkey, msg)
-    pub = privtopub(privkey)
-    assert verify(pub, msg, sig)
+    sig = Sign(privkey, msg)
+    pub = PrivToPub(privkey)
+    assert Verify(pub, msg, sig)
 
 
 @pytest.mark.parametrize(
@@ -168,11 +168,11 @@ def test_bls_core(privkey):
     ]
 )
 def test_signature_aggregation(msg, privkeys):
-    sigs = [sign(k, msg) for k in privkeys]
-    pubs = [privtopub(k) for k in privkeys]
-    aggsig = aggregate_signatures(sigs)
-    aggpub = aggregate_pubkeys(pubs)
-    assert verify(aggpub, msg, aggsig)
+    sigs = [Sign(k, msg) for k in privkeys]
+    pubs = [PrivToPub(k) for k in privkeys]
+    aggsig = AggregateSignatures(sigs)
+    aggpub = AggregatePubkeys(pubs)
+    assert Verify(aggpub, msg, aggsig)
 
 
 @pytest.mark.parametrize(
@@ -190,21 +190,21 @@ def test_signature_aggregation(msg, privkeys):
     ]
 )
 def test_multi_aggregation(msg_1, msg_2, privkeys_1, privkeys_2):
-    sigs_1 = [sign(k, msg_1) for k in privkeys_1]
-    pubs_1 = [privtopub(k) for k in privkeys_1]
-    aggsig_1 = aggregate_signatures(sigs_1)
-    aggpub_1 = aggregate_pubkeys(pubs_1)
+    sigs_1 = [Sign(k, msg_1) for k in privkeys_1]
+    pubs_1 = [PrivToPub(k) for k in privkeys_1]
+    aggsig_1 = AggregateSignatures(sigs_1)
+    aggpub_1 = AggregatePubkeys(pubs_1)
 
-    sigs_2 = [sign(k, msg_2) for k in privkeys_2]
-    pubs_2 = [privtopub(k) for k in privkeys_2]
-    aggsig_2 = aggregate_signatures(sigs_2)
-    aggpub_2 = aggregate_pubkeys(pubs_2)
+    sigs_2 = [Sign(k, msg_2) for k in privkeys_2]
+    pubs_2 = [PrivToPub(k) for k in privkeys_2]
+    aggsig_2 = AggregateSignatures(sigs_2)
+    aggpub_2 = AggregatePubkeys(pubs_2)
 
     messages = [msg_1, msg_2]
     pubs = [aggpub_1, aggpub_2]
-    aggsig = aggregate_signatures([aggsig_1, aggsig_2])
+    aggsig = AggregateSignatures([aggsig_1, aggsig_2])
 
-    assert aggregate_verify(
+    assert AggregateVerify(
         pks=pubs,
         messages=messages,
         signature=aggsig,

--- a/tests/test_bls.py
+++ b/tests/test_bls.py
@@ -10,6 +10,7 @@ from py_ecc.bls import (
     Sign,
     Verify,
     AggregateVerify,
+    FastAggregateVerify,
 )
 from py_ecc.bls.utils import (
     compress_G1,
@@ -207,5 +208,23 @@ def test_multi_aggregation(msg_1, msg_2, privkeys_1, privkeys_2):
     assert AggregateVerify(
         pks=pubs,
         messages=messages,
+        signature=aggsig,
+    )
+
+
+@pytest.mark.parametrize(
+    'msg, privkeys',
+    [
+        (b'\x12' * 32, [1, 5, 124, 735, 127409812145, 90768492698215092512159, 0]),
+        (b'\x34' * 32, [42, 666, 1274099945, 4389392949595]),
+    ]
+)
+def test_fast_aggregate_verify(msg, privkeys):
+    sigs = [Sign(sk, msg) for sk in privkeys]
+    pubs = [PrivToPub(sk) for sk in privkeys]
+    aggsig = AggregateSignatures(sigs)
+    assert FastAggregateVerify(
+        pks=pubs,
+        message=msg,
         signature=aggsig,
     )

--- a/tests/test_bls_hash_to_G2.py
+++ b/tests/test_bls_hash_to_G2.py
@@ -13,7 +13,7 @@ from py_ecc.bls import (
     privtopub,
     sign,
     verify,
-    verify_multiple,
+    aggregate_verify,
 )
 from py_ecc.bls.utils import (
     compress_G1,

--- a/tests/test_bls_hash_to_G2.py
+++ b/tests/test_bls_hash_to_G2.py
@@ -2,47 +2,16 @@
 These are temporary tests to check the functionality of helper functions in `hash_to_G2`
 They should be removed and replaced with a final version when hash to curve is complete.
 """
-from eth_utils import (
-    big_endian_to_int,
-)
 import pytest
 
-from py_ecc.bls import (
-    aggregate_pubkeys,
-    aggregate_signatures,
-    privtopub,
-    sign,
-    verify,
-    aggregate_verify,
-)
-from py_ecc.bls.utils import (
-    compress_G1,
-    compress_G2,
-    decompress_G1,
-    decompress_G2,
-    hash_to_G2,
-    signature_to_G2,
-)
-from py_ecc.bls.constants import (
-    POW_2_381,
-    POW_2_382,
-    POW_2_383,
-)
+from py_ecc.bls.utils import hash_to_G2
+
 from py_ecc.fields import (
-    optimized_bls12_381_FQ as FQ,
     optimized_bls12_381_FQ2 as FQ2,
 )
 from py_ecc.optimized_bls12_381 import (
-    G1,
-    G2,
-    Z1,
-    Z2,
-    b,
     b2,
     is_on_curve,
-    multiply,
-    normalize,
-    field_modulus as q,
     iso_map_G2,
 )
 


### PR DESCRIPTION
### What was wrong?

The BLS specs didn't implement the interface specified by the IETF standards.

### How was it fixed?

The interface for the specified by the IETF BLS standards' G2 Proof of Possession ciphersuite was implemented.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/12530043/70448931-61239480-1aa1-11ea-940e-8cd651d19a2d.png)
