### PR TITLE
Add python 3.8 test CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,13 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-core
+  py38-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-core
+
 workflows:
   version: 2
   test:
@@ -68,3 +75,4 @@ workflows:
       - py35-core
       - py36-core
       - py37-core
+      - py38-core

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{35,36,37}-core
+    py{35,36,37,38}-core
     lint
 
 [flake8]
@@ -19,6 +19,7 @@ basepython =
     py35: python3.5
     py36: python3.6
     py37: python3.7
+    py38: python3.8
 
 [testenv:lint]
 basepython=python


### PR DESCRIPTION
### What was wrong?
Fix #90
To make sure we support Python 3.8 env.

### How was it fixed?
Added py38 CI job


#### Cute Animal Picture

![wombat-1176175_640](https://user-images.githubusercontent.com/9263930/81155350-6d137400-8fb7-11ea-824a-4e0999729776.jpg)
