### PR TITLE
Optimized BLS-12-381 Miller loop is now 33% faster

### DIFF
--- a/py_ecc/optimized_bls12_381/optimized_curve.py
+++ b/py_ecc/optimized_bls12_381/optimized_curve.py
@@ -154,10 +154,10 @@ def twist(pt: Optimized_Point3D[FQP]) -> Optimized_Point3D[FQ12]:
     xcoeffs = [_x.coeffs[0] - _x.coeffs[1], _x.coeffs[1]]
     ycoeffs = [_y.coeffs[0] - _y.coeffs[1], _y.coeffs[1]]
     zcoeffs = [_z.coeffs[0] - _z.coeffs[1], _z.coeffs[1]]
-    nx = FQ12([xcoeffs[0]] + [0] * 5 + [xcoeffs[1]] + [0] * 5)
+    nx = FQ12([0] + [xcoeffs[0]] + [0] * 5 + [xcoeffs[1]] + [0] * 4)
     ny = FQ12([ycoeffs[0]] + [0] * 5 + [ycoeffs[1]] + [0] * 5)
-    nz = FQ12([zcoeffs[0]] + [0] * 5 + [zcoeffs[1]] + [0] * 5)
-    return (nx / w ** 2, ny / w**3, nz)
+    nz = FQ12([0] * 3 + [zcoeffs[0]] + [0] * 5 + [zcoeffs[1]] + [0] * 2)
+    return (nx, ny, nz)
 
 
 # Check that the twist creates a point that is on the curve

--- a/py_ecc/optimized_bls12_381/optimized_pairing.py
+++ b/py_ecc/optimized_bls12_381/optimized_pairing.py
@@ -115,7 +115,7 @@ def miller_loop(Q: Optimized_Point3D[FQ2],
         return FQ12.one()
     cast_P = cast_point_to_fq12(P)
     twist_R = twist_Q = twist(Q)
-    R = Q  # type: Optimized_Point3D[FQ12]
+    R = Q  # type: Optimized_Point3D[FQ2]
     f_num, f_den = FQ12.one(), FQ12.one()
     # for i in range(log_ate_loop_count, -1, -1):
     for v in pseudo_binary_encoding[62::-1]:

--- a/py_ecc/optimized_bls12_381/optimized_pairing.py
+++ b/py_ecc/optimized_bls12_381/optimized_pairing.py
@@ -107,6 +107,7 @@ assert linefunc(one, one, one)[0] == FQ(0)
 assert linefunc(one, one, two)[0] != FQ(0)
 assert linefunc(one, one, negtwo)[0] == FQ(0)
 
+
 # Main miller loop
 def miller_loop(Q: Optimized_Point3D[FQ2],
                 P: Optimized_Point3D[FQ],
@@ -114,21 +115,22 @@ def miller_loop(Q: Optimized_Point3D[FQ2],
     if Q is None or P is None:
         return FQ12.one()
     cast_P = cast_point_to_fq12(P)
-    twist_Q = twist(Q)
-    R = Q  # type: Optimized_Point3D[FQ2]
+    twist_R = twist_Q = twist(Q)
+    R = Q  # type: Optimized_Point3D[FQ12]
     f_num, f_den = FQ12.one(), FQ12.one()
     # for i in range(log_ate_loop_count, -1, -1):
     for v in pseudo_binary_encoding[62::-1]:
-        twist_R = twist(R)
         _n, _d = linefunc(twist_R, twist_R, cast_P)
         f_num = f_num * f_num * _n
         f_den = f_den * f_den * _d
         R = double(R)
+        twist_R = twist(R)
         if v == 1:
             _n, _d = linefunc(twist_R, twist_Q, cast_P)
             f_num = f_num * _n
             f_den = f_den * _d
             R = add(R, Q)
+            twist_R = twist(R)
     # assert R == multiply(Q, ate_loop_count)
     # Q1 = (Q[0] ** field_modulus, Q[1] ** field_modulus, Q[2] ** field_modulus)
     # assert is_on_curve(Q1, b12)

--- a/py_ecc/optimized_bls12_381/optimized_pairing.py
+++ b/py_ecc/optimized_bls12_381/optimized_pairing.py
@@ -20,7 +20,6 @@ from .optimized_curve import (
     add,
     multiply,
     is_on_curve,
-    neg,
     twist,
     b,
     b2,


### PR DESCRIPTION
Does the point multiplication step in the Miller loop in G2 rather than G12, increasing speed of computing the Miller loop by ~33% (0.2 sec -> 0.15 sec on my computer). Also includes a much faster twist routine.