### PR TITLE
Update to IETF BLS draft 04 and add some input validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pip install py_ecc
 
 ## BLS Signatures
 
-`py_ecc` implements the [IETF BLS draft standard v3](https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-03) as per the inter-blockchain standardization agreement. The BLS standards specify [different ciphersuites](https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-03#section-4) which each have different functionality to accommodate various use cases. The following ciphersuites are available from this library:
+`py_ecc` implements the [IETF BLS draft standard v4](https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04) as per the inter-blockchain standardization agreement. The BLS standards specify [different ciphersuites](https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04#section-4) which each have different functionality to accommodate various use cases. The following ciphersuites are available from this library:
 
 - `G2Basic` also known as `BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_`
 - `G2MessageAugmentation` also known as `BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_AUG_`

--- a/tests/bls/ciphersuites/test_g2_basic.py
+++ b/tests/bls/ciphersuites/test_g2_basic.py
@@ -2,15 +2,15 @@ import pytest
 from py_ecc.bls import G2Basic
 
 @pytest.mark.parametrize(
-    'SKs,messages,success',
+    'SKs,messages,result',
     [
-        (range(10), range(10), True),
-        (range(3), (b'42', b'69', b'42'), False),  # Test duplicate messages fail
+        (list(range(1, 11)), list(range(1, 11)), True),
+        (list(range(1, 4)), (b'42', b'69', b'42'), False),  # Test duplicate messages fail
     ]
 )
-def test_aggregate_verify(SKs, messages, success):
+def test_aggregate_verify(SKs, messages, result):
     PKs = [G2Basic.SkToPk(SK) for SK in SKs]
     messages = [bytes(msg) for msg in messages]
     signatures = [G2Basic.Sign(SK, msg) for SK, msg in zip(SKs, messages)]
     aggregate_signature = G2Basic.Aggregate(signatures)
-    assert G2Basic.AggregateVerify(PKs, messages, aggregate_signature) == success
+    assert G2Basic.AggregateVerify(PKs, messages, aggregate_signature) == result

--- a/tests/bls/ciphersuites/test_g2_basic.py
+++ b/tests/bls/ciphersuites/test_g2_basic.py
@@ -1,5 +1,15 @@
 import pytest
+
+from eth_utils import (
+    ValidationError,
+)
+
 from py_ecc.bls import G2Basic
+from py_ecc.bls.ciphersuites import (
+    Z1_PUBKEY,
+    Z2_SIGNATURE,
+)
+
 
 @pytest.mark.parametrize(
     'SKs,messages,result',
@@ -14,3 +24,55 @@ def test_aggregate_verify(SKs, messages, result):
     signatures = [G2Basic.Sign(SK, msg) for SK, msg in zip(SKs, messages)]
     aggregate_signature = G2Basic.Aggregate(signatures)
     assert G2Basic.AggregateVerify(PKs, messages, aggregate_signature) == result
+
+
+@pytest.mark.parametrize(
+    'privkey, success',
+    [
+        (1, True),
+        (0, False),
+        ('hello', False),  # wrong type
+    ]
+)
+def test_sk_to_pk(privkey, success):
+    if success:
+        G2Basic.SkToPk(privkey)
+    else:
+        with pytest.raises(ValidationError):
+            G2Basic.SkToPk(privkey)
+
+
+@pytest.mark.parametrize(
+    'privkey, message, success',
+    [
+        (1, b'message', True),
+        (0, b'message', False),
+        ('hello', b'message', False),  # wrong type privkey
+        (1, 123, False),  # wrong type message
+    ]
+)
+def test_sign(privkey, message, success):
+    if success:
+        G2Basic.Sign(privkey, message)
+    else:
+        with pytest.raises(ValidationError):
+            G2Basic.Sign(privkey, message)
+
+
+
+@pytest.mark.parametrize(
+    'signatures, success',
+    [
+        ([G2Basic.Sign(1, b'helloworld')], True),
+        ([G2Basic.Sign(1, b'helloworld'), G2Basic.Sign(2, b'helloworld')], True),
+        ([Z2_SIGNATURE], True),
+        (['hello'], False),
+        ([], False),
+    ]
+)
+def test_aggregate(signatures, success):
+    if success:
+        G2Basic.Aggregate(signatures)
+    else:
+        with pytest.raises(ValidationError):
+            G2Basic.Aggregate(signatures)

--- a/tests/bls/ciphersuites/test_g2_message_augmentation.py
+++ b/tests/bls/ciphersuites/test_g2_message_augmentation.py
@@ -11,7 +11,6 @@ from py_ecc.bls import G2MessageAugmentation
         (735),
         (127409812145),
         (90768492698215092512159),
-        (0),
     ]
 )
 def test_sign_verify(privkey):
@@ -24,7 +23,7 @@ def test_sign_verify(privkey):
 @pytest.mark.parametrize(	
     'SKs,messages',	
     [	
-        (range(10), range(10)),	
+        (list(range(1, 11)), list(range(1, 11)))
     ]	
 )	
 def test_aggregate_verify(SKs, messages):	

--- a/tests/bls/ciphersuites/test_g2_pop.py
+++ b/tests/bls/ciphersuites/test_g2_pop.py
@@ -4,12 +4,28 @@ from py_ecc.bls import G2ProofOfPossession
 from py_ecc.optimized_bls12_381 import (
     G1,
     G2,
+    Z1,
+    Z2,
     multiply,
 )
 from py_ecc.bls.g2_primatives import (
     G1_to_pubkey,
     G2_to_signature,
 )
+
+
+Z1_PUBKEY = G1_to_pubkey(Z1)
+Z2_SIGNATURE = G2_to_signature(Z2)
+
+
+sample_message = b'\x12' * 32
+
+
+def compute_aggregate_signature(SKs, message):
+    PKs = [G2ProofOfPossession.SkToPk(sk) for sk in SKs]
+    signatures = [G2ProofOfPossession.Sign(sk, message) for sk in SKs]
+    aggregate_signature = G2ProofOfPossession.Aggregate(signatures)
+    return (PKs, aggregate_signature)
 
 
 @pytest.mark.parametrize(
@@ -40,13 +56,38 @@ def test_aggregate_pks(signature_points, result_point):
 
 
 @pytest.mark.parametrize(
-    'SKs,message',
+    'PK, message, signature, result',
     [
-        (range(5), b'11'*48),
+        (G2ProofOfPossession.SkToPk(1), sample_message, G2ProofOfPossession.Sign(1, sample_message), True),
+        # (None, sample_message, Z2_SIGNATURE, False),
+        (Z1_PUBKEY, sample_message, Z2_SIGNATURE, False),
     ]
 )
-def test_fast_aggregate_verify(SKs, message):
-    PKs = [G2ProofOfPossession.SkToPk(sk) for sk in SKs]
-    signatures = [G2ProofOfPossession.Sign(sk, message) for sk in SKs]
-    aggregate_signature = G2ProofOfPossession.Aggregate(signatures)
-    assert G2ProofOfPossession.FastAggregateVerify(PKs, message, aggregate_signature)
+def test_verify(PK, message, signature, result):
+    assert G2ProofOfPossession.Verify(PK, message, signature) == result
+
+
+@pytest.mark.parametrize(
+    'PKs, aggregate_signature, message, result',
+    [
+        (*compute_aggregate_signature(SKs=[1], message=sample_message), sample_message, True),
+        (*compute_aggregate_signature(SKs=tuple(range(1, 5)), message=sample_message), sample_message, True),
+        ([], Z2_SIGNATURE, sample_message, False),
+        ([G2ProofOfPossession.SkToPk(1), Z1_PUBKEY], G2ProofOfPossession.Sign(1, sample_message), sample_message, False),
+    ]
+)
+def test_aggregate_verify(PKs, aggregate_signature, message, result):
+    assert G2ProofOfPossession.AggregateVerify(PKs, (message,) * len(PKs), aggregate_signature) == result
+
+
+@pytest.mark.parametrize(
+    'PKs, aggregate_signature, message, result',
+    [
+        (*compute_aggregate_signature(SKs=[1], message=sample_message), sample_message, True),
+        (*compute_aggregate_signature(SKs=tuple(range(1, 5)), message=sample_message), sample_message, True),
+        ([], Z2_SIGNATURE, sample_message, False),
+        ([G2ProofOfPossession.SkToPk(1), Z1_PUBKEY], G2ProofOfPossession.Sign(1, sample_message), sample_message, False),
+    ]
+)
+def test_fast_aggregate_verify(PKs, aggregate_signature, message, result):
+    assert G2ProofOfPossession.FastAggregateVerify(PKs, message, aggregate_signature) == result

--- a/tests/bls/ciphersuites/test_g2_pop.py
+++ b/tests/bls/ciphersuites/test_g2_pop.py
@@ -1,21 +1,18 @@
 import pytest
 
 from py_ecc.bls import G2ProofOfPossession
+from py_ecc.bls.ciphersuites import (
+    Z1_PUBKEY,
+    Z2_SIGNATURE,
+)
 from py_ecc.optimized_bls12_381 import (
     G1,
-    G2,
-    Z1,
-    Z2,
     multiply,
 )
 from py_ecc.bls.g2_primatives import (
     G1_to_pubkey,
     G2_to_signature,
 )
-
-
-Z1_PUBKEY = G1_to_pubkey(Z1)
-Z2_SIGNATURE = G2_to_signature(Z2)
 
 
 sample_message = b'\x12' * 32
@@ -59,7 +56,7 @@ def test_aggregate_pks(signature_points, result_point):
     'PK, message, signature, result',
     [
         (G2ProofOfPossession.SkToPk(1), sample_message, G2ProofOfPossession.Sign(1, sample_message), True),
-        # (None, sample_message, Z2_SIGNATURE, False),
+        (None, sample_message, Z2_SIGNATURE, False),  # wrong type
         (Z1_PUBKEY, sample_message, Z2_SIGNATURE, False),
     ]
 )

--- a/tests/bls/test_g2_core.py
+++ b/tests/bls/test_g2_core.py
@@ -32,7 +32,6 @@ def test_key_validate(pubkey, success):
         (735),
         (127409812145),
         (90768492698215092512159),
-        (0),
     ]
 )
 def test_sign_verify(privkey):
@@ -58,7 +57,7 @@ def test_aggregate(signature_points, result_point):
 @pytest.mark.parametrize(
     'SKs,messages',
     [
-        (range(5), range(5)),
+        (list(range(1, 6)), list(range(1, 6))),
     ]
 )
 def test_core_aggregate_verify(SKs, messages):


### PR DESCRIPTION
### What was wrong?

Update to [IETF BLS draft 04](https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04)


### How was it fixed?

1. `SK=0` (point at infinity PK) is disallowed in -04 spec. Update `KeyGen`, `KeyValidate` correspondingly.
2. Add the missing `KeyValidate` to `_CoreAggregateVerify`: It wasn't a bug because `_CoreAggregateVerify` itself has checked  `pubkey_to_G1`, but now it also needs to check the point at infinity PK.
3. Add input validations APIs `_is_valid_privkey`, `_is_valid_pubkey`, `_is_valid_message`, and `_is_valid_signature`. Reasons:
    - To check input types strictly since Python is a dynamically-typed language.
    - To follow the spec description more tightly.
    - As a workaround for PopVerify-able checks. e.g., ensure PK is not the point at infinity in `FastAggregateVerify`.

#### Cute Animal Picture
![moose-70254_640](https://user-images.githubusercontent.com/9263930/94001248-d95a0d00-fdca-11ea-9d29-b09771361050.jpg)

