### PR TITLE
Added bls import to init.py

### DIFF
--- a/py_ecc/__init__.py
+++ b/py_ecc/__init__.py
@@ -9,3 +9,4 @@ from py_ecc import bn128  # noqa: F401
 from py_ecc import optimized_bn128  # noqa: F401
 from py_ecc import bls12_381  # noqa: F401
 from py_ecc import optimized_bls12_381  # noqa: F401
+from py_ecc import bls  # noqa: F401


### PR DESCRIPTION
Fixes a bug where importing py_ecc does not make py_ecc.bls accessible.