### PR TITLE
Add strict deserialization format validation

### DIFF
--- a/py_ecc/bls/ciphersuites.py
+++ b/py_ecc/bls/ciphersuites.py
@@ -106,7 +106,7 @@ class BaseG2Ciphersuite(abc.ABC):
     def KeyValidate(PK: BLSPubkey) -> bool:
         try:
             pubkey_point = pubkey_to_G1(PK)
-        except ValidationError:
+        except Exception:
             return False
 
         if is_inf(pubkey_point):
@@ -114,7 +114,7 @@ class BaseG2Ciphersuite(abc.ABC):
 
         try:
             pubkey_subgroup_check(pubkey_point)
-        except ValidationError:
+        except Exception:
             return False
 
         return True

--- a/py_ecc/bls/ciphersuites.py
+++ b/py_ecc/bls/ciphersuites.py
@@ -106,7 +106,7 @@ class BaseG2Ciphersuite(abc.ABC):
     def KeyValidate(PK: BLSPubkey) -> bool:
         try:
             pubkey_point = pubkey_to_G1(PK)
-        except Exception:
+        except (ValidationError, ValueError, AssertionError):
             return False
 
         if is_inf(pubkey_point):
@@ -114,7 +114,7 @@ class BaseG2Ciphersuite(abc.ABC):
 
         try:
             pubkey_subgroup_check(pubkey_point)
-        except Exception:
+        except (ValidationError, ValueError, AssertionError):
             return False
 
         return True

--- a/py_ecc/bls/constants.py
+++ b/py_ecc/bls/constants.py
@@ -15,6 +15,7 @@ EIGTH_ROOTS_OF_UNITY = tuple(
 POW_2_381 = 2**381
 POW_2_382 = 2**382
 POW_2_383 = 2**383
+POW_2_384 = 2**384
 
 # Paramaters for hashing to the field as specified in:
 # https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-09#section-8.8.1

--- a/py_ecc/bls/point_compression.py
+++ b/py_ecc/bls/point_compression.py
@@ -91,7 +91,7 @@ def decompress_G1(z: G1Compressed) -> G1Uncompressed:
     is_inf_pt = is_point_at_infinity(z)
 
     if b_flag != is_inf_pt:
-        raise ValueError(f"b_flag should be {int(is_inf_pt)}")
+        raise ValueError("b_flag should be %d" % int(is_inf_pt))
 
     if is_inf_pt:
         # 3 MSBs should be 110
@@ -224,7 +224,7 @@ def decompress_G2(p: G2Compressed) -> G2Uncompressed:
 
     # Validate z2 flags
     c_flag2, b_flag2, a_flag2 = get_flags(z2)
-    if not (c_flag2 == b_flag2 == a_flag2 and a_flag2 is False):
+    if not (c_flag2 is b_flag2 and b_flag2 is a_flag2 and a_flag2 is False):
         raise ValueError("a_flag2, b_flag2, and c_flag2 should always set to 0")
 
     return (x, y, FQ2([1, 0]))

--- a/py_ecc/bls/point_compression.py
+++ b/py_ecc/bls/point_compression.py
@@ -45,6 +45,10 @@ def get_flags(z: int) -> Tuple[bool, bool, bool]:
 
 
 def is_point_at_infinity(z1: int, z2: Optional[int] = None) -> bool:
+    """
+    If z2 is None, the given z1 is a G1 point.
+    Else, (z1, z2) is a G2 point.
+    """
     return (z1 % POW_2_381 == 0) and (
         z2 is None or (z2 is not None and z2 == 0)
     )

--- a/py_ecc/bls/point_compression.py
+++ b/py_ecc/bls/point_compression.py
@@ -194,6 +194,12 @@ def decompress_G2(p: G2Compressed) -> G2Uncompressed:
     # Else, not point at infinity
     # 3 MSBs should be 100 or 101
     x1 = z1 % POW_2_381
+
+    # Validate z2 flags
+    c_flag2, b_flag2, a_flag2 = get_flags(z2)
+    if not (c_flag2 is b_flag2 and b_flag2 is a_flag2 and a_flag2 is False):
+        raise ValueError("a_flag2, b_flag2, and c_flag2 should always set to 0")
+
     x2 = z2
     # x1 is the imaginary part, x2 is the real part
     x = FQ2([x2, x1])
@@ -214,10 +220,4 @@ def decompress_G2(p: G2Compressed) -> G2Uncompressed:
         raise ValueError(
             "The given point is not on the twisted curve over FQ**2"
         )
-
-    # Validate z2 flags
-    c_flag2, b_flag2, a_flag2 = get_flags(z2)
-    if not (c_flag2 is b_flag2 and b_flag2 is a_flag2 and a_flag2 is False):
-        raise ValueError("a_flag2, b_flag2, and c_flag2 should always set to 0")
-
     return (x, y, FQ2([1, 0]))

--- a/py_ecc/bls/point_compression.py
+++ b/py_ecc/bls/point_compression.py
@@ -49,9 +49,7 @@ def is_point_at_infinity(z1: int, z2: Optional[int] = None) -> bool:
     If z2 is None, the given z1 is a G1 point.
     Else, (z1, z2) is a G2 point.
     """
-    return (z1 % POW_2_381 == 0) and (
-        z2 is None or (z2 is not None and z2 == 0)
-    )
+    return (z1 % POW_2_381 == 0) and (z2 is None or z2 == 0)
 
 
 #
@@ -87,7 +85,6 @@ def decompress_G1(z: G1Compressed) -> G1Uncompressed:
     if not c_flag:
         raise ValueError("c_flag should be 1")
 
-    # b_flag == 1 indicates the point at infinity
     is_inf_pt = is_point_at_infinity(z)
 
     if b_flag != is_inf_pt:
@@ -179,14 +176,10 @@ def decompress_G2(p: G2Compressed) -> G2Uncompressed:
     c_flag1, b_flag1, a_flag1 = get_flags(z1)
 
     # c_flag == 1 indicates the compressed form
-    if not c_flag1:
-        raise ValueError("c_flag should be 1")
-
     # MSB should be 1
     if not c_flag1:
         raise ValueError("c_flag should be 1")
 
-    # b_flag == 1 indicates the point at infinity
     is_inf_pt = is_point_at_infinity(z1, z2)
 
     if b_flag1 != is_inf_pt:

--- a/tests/bls/test_g2_core.py
+++ b/tests/bls/test_g2_core.py
@@ -16,7 +16,7 @@ from py_ecc.bls import G2Basic
     'pubkey,success',
     [
         (G2Basic.SkToPk(42), True),
-        (b'11' * 48, False),
+        (b'\x11' * 48, False),
     ]
 )
 def test_key_validate(pubkey, success):

--- a/tests/bls/test_g2_primatives.py
+++ b/tests/bls/test_g2_primatives.py
@@ -17,7 +17,7 @@ from py_ecc.bls.g2_primatives import (
 
 def test_decompress_G2_with_no_modular_square_root_found():
     with pytest.raises(ValueError, match="Failed to find a modular squareroot"):
-        signature_to_G2(b'\x11' * 96)
+        signature_to_G2(b'\xA0' + b'\x11' * 95)
 
 
 def test_G2_signature_encode_decode():

--- a/tests/bls/test_point_compression.py
+++ b/tests/bls/test_point_compression.py
@@ -75,9 +75,9 @@ compressed_z1 = compress_G1(Z1)
     [
         (compressed_g1, None),  # baseline
         (compressed_g1 & ~(1<<383), "c_flag should be 1"),  # set c_flag to 0
-        (compressed_g1 | (1<<382), "Should be point at infinity"),  # set b_flag to 1
-        (compressed_z1 & ~(1<<382), "a point at infinity should have b_flag 1"),  # set b_flag to 0
-        (compressed_z1 | (1<<381), "a_flag should be 0"),  # set a_flag to 1
+        (compressed_g1 | (1<<382), "b_flag should be 0"),  # set b_flag to 1
+        (compressed_z1 & ~(1<<382), "b_flag should be 1"),  # set b_flag to 0
+        (compressed_z1 | (1<<381), "a point at infinity should have a_flag == 0"),  # set a_flag to 1
     ]
 )
 def test_decompress_G1_edge_case(z, error_message):
@@ -140,9 +140,9 @@ compressed_z2 = compress_G2(Z2)
     [
         (compressed_g2, None),  # baseline
         ((compressed_g2[0] & ~(1<<383), compressed_g2[1]), "c_flag should be 1"),  # set c_flag1 to 0
-        ((compressed_g2[0] | (1<<382), compressed_g2[1]), "Should be point at infinity"),  # set b_flag1 to 1
-        ((compressed_z2[0] & ~(1<<382), compressed_z2[1]), "a point at infinity should have b_flag 1"),  # set b_flag1 to 0
-        ((compressed_z2[0] | (1<<381), compressed_z2[1]), "a_flag should be 0"),  # set a_flag1 to 1
+        ((compressed_g2[0] | (1<<382), compressed_g2[1]), "b_flag should be 0"),  # set b_flag1 to 1
+        ((compressed_z2[0] & ~(1<<382), compressed_z2[1]), "b_flag should be 1"),  # set b_flag1 to 0
+        ((compressed_z2[0] | (1<<381), compressed_z2[1]), "a point at infinity should have a_flag == 0"),  # set a_flag1 to 1
         ((compressed_g2[0], compressed_z2[1] | (1<<383)), "a_flag2, b_flag2, and c_flag2 should always set to 0"),  # set c_flag2 to 1
         ((compressed_g2[0], compressed_z2[1] | (1<<382)), "a_flag2, b_flag2, and c_flag2 should always set to 0"),  # set b_flag2 to 1
         ((compressed_g2[0], compressed_z2[1] | (1<<381)), "a_flag2, b_flag2, and c_flag2 should always set to 0"),  # set a_flag2 to 1

--- a/tests/bls/test_point_compression.py
+++ b/tests/bls/test_point_compression.py
@@ -10,10 +10,6 @@ from py_ecc.fields import (
     optimized_bls12_381_FQ as FQ,
     optimized_bls12_381_FQ2 as FQ2,
 )
-from py_ecc.bls.hash import (
-    i2osp,
-    os2ip,
-)
 from py_ecc.bls.constants import (
     POW_2_381,
     POW_2_382,

--- a/tests/bls/test_point_compression.py
+++ b/tests/bls/test_point_compression.py
@@ -80,7 +80,7 @@ compressed_z1 = compress_G1(Z1)
         (compressed_g1, None),  # baseline
         (compressed_g1 & ~(1<<383), "c_flag should be 1"),  # set c_flag to 0
         (compressed_g1 | (1<<382), "Should be point at infinity"),  # set b_flag to 1
-        (compressed_z1 & ~(1<<382), "b_flag should be 1"),  # set b_flag to 0
+        (compressed_z1 & ~(1<<382), "a point at infinity should have b_flag 1"),  # set b_flag to 0
         (compressed_z1 | (1<<381), "a_flag should be 0"),  # set a_flag to 1
     ]
 )
@@ -145,7 +145,7 @@ compressed_z2 = compress_G2(Z2)
         (compressed_g2, None),  # baseline
         ((compressed_g2[0] & ~(1<<383), compressed_g2[1]), "c_flag should be 1"),  # set c_flag1 to 0
         ((compressed_g2[0] | (1<<382), compressed_g2[1]), "Should be point at infinity"),  # set b_flag1 to 1
-        ((compressed_z2[0] & ~(1<<382), compressed_z2[1]), "b_flag should be 1"),  # set b_flag1 to 0
+        ((compressed_z2[0] & ~(1<<382), compressed_z2[1]), "a point at infinity should have b_flag 1"),  # set b_flag1 to 0
         ((compressed_z2[0] | (1<<381), compressed_z2[1]), "a_flag should be 0"),  # set a_flag1 to 1
         ((compressed_g2[0], compressed_z2[1] | (1<<383)), "a_flag2, b_flag2, and c_flag2 should always set to 0"),  # set c_flag2 to 1
         ((compressed_g2[0], compressed_z2[1] | (1<<382)), "a_flag2, b_flag2, and c_flag2 should always set to 0"),  # set b_flag2 to 1

--- a/tests/bls/test_point_compression.py
+++ b/tests/bls/test_point_compression.py
@@ -18,6 +18,7 @@ from py_ecc.bls.constants import (
     POW_2_381,
     POW_2_382,
     POW_2_383,
+    POW_2_384,
 )
 from py_ecc.optimized_bls12_381 import (
     G1,
@@ -49,7 +50,7 @@ def test_G1_compress_and_decompress_flags(pt, on_curve, is_infinity):
     z = compress_G1(pt)
     if on_curve:
         x = z % POW_2_381
-        c_flag = (z % 2**384) // POW_2_383
+        c_flag = (z % POW_2_384) // POW_2_383
         b_flag = (z % POW_2_383) // POW_2_382
         a_flag = (z % POW_2_382) // POW_2_381
         assert x < q
@@ -107,11 +108,11 @@ def test_G2_compress_and_decompress_flags(pt, on_curve, is_infinity):
     if on_curve:
         z1, z2 = compress_G2(pt)
         x1 = z1 % POW_2_381
-        c_flag1 = (z1 % 2**384) // POW_2_383
+        c_flag1 = (z1 % POW_2_384) // POW_2_383
         b_flag1 = (z1 % POW_2_383) // POW_2_382
         a_flag1 = (z1 % POW_2_382) // POW_2_381
         x2 = z2 % POW_2_381
-        c_flag2 = (z2 % 2**384) // POW_2_383
+        c_flag2 = (z2 % POW_2_384) // POW_2_383
         b_flag2 = (z2 % POW_2_383) // POW_2_382
         a_flag2 = (z2 % POW_2_382) // POW_2_381
         assert x1 < q
@@ -147,6 +148,8 @@ compressed_z2 = compress_G2(Z2)
         ((compressed_z2[0] & ~(1<<382), compressed_z2[1]), "b_flag should be 1"),  # set b_flag1 to 0
         ((compressed_z2[0] | (1<<381), compressed_z2[1]), "a_flag should be 0"),  # set a_flag1 to 1
         ((compressed_g2[0], compressed_z2[1] | (1<<383)), "a_flag2, b_flag2, and c_flag2 should always set to 0"),  # set c_flag2 to 1
+        ((compressed_g2[0], compressed_z2[1] | (1<<382)), "a_flag2, b_flag2, and c_flag2 should always set to 0"),  # set b_flag2 to 1
+        ((compressed_g2[0], compressed_z2[1] | (1<<381)), "a_flag2, b_flag2, and c_flag2 should always set to 0"),  # set a_flag2 to 1
     ]
 )
 def test_decompress_G2_edge_case(z, error_message):

--- a/tests/bls/test_point_compression.py
+++ b/tests/bls/test_point_compression.py
@@ -10,6 +10,10 @@ from py_ecc.fields import (
     optimized_bls12_381_FQ as FQ,
     optimized_bls12_381_FQ2 as FQ2,
 )
+from py_ecc.bls.hash import (
+    i2osp,
+    os2ip,
+)
 from py_ecc.bls.constants import (
     POW_2_381,
     POW_2_382,
@@ -65,6 +69,28 @@ def test_G1_compress_and_decompress_flags(pt, on_curve, is_infinity):
             decompress_G1(z)
 
 
+compressed_g1 = compress_G1(G1)
+compressed_z1 = compress_G1(Z1)
+
+
+@pytest.mark.parametrize(
+    'z, error_message',
+    [
+        (compressed_g1, None),  # baseline
+        (compressed_g1 & ~(1<<383), "c_flag should be 1"),  # set c_flag to 0
+        (compressed_g1 | (1<<382), "Should be point at infinity"),  # set b_flag to 1
+        (compressed_z1 & ~(1<<382), "b_flag should be 1"),  # set b_flag to 0
+        (compressed_z1 | (1<<381), "a_flag should be 0"),  # set a_flag to 1
+    ]
+)
+def test_decompress_G1_edge_case(z, error_message):
+    if error_message is None:
+        decompress_G1(z)
+    else:
+        with pytest.raises(ValueError, match=error_message):
+            decompress_G1(z)
+
+
 @pytest.mark.parametrize(
     'pt,on_curve,is_infinity',
     [
@@ -106,3 +132,26 @@ def test_G2_compress_and_decompress_flags(pt, on_curve, is_infinity):
     else:
         with pytest.raises(ValueError):
             compress_G2(pt)
+
+
+compressed_g2 = compress_G2(G2)
+compressed_z2 = compress_G2(Z2)
+
+
+@pytest.mark.parametrize(
+    'z, error_message',
+    [
+        (compressed_g2, None),  # baseline
+        ((compressed_g2[0] & ~(1<<383), compressed_g2[1]), "c_flag should be 1"),  # set c_flag1 to 0
+        ((compressed_g2[0] | (1<<382), compressed_g2[1]), "Should be point at infinity"),  # set b_flag1 to 1
+        ((compressed_z2[0] & ~(1<<382), compressed_z2[1]), "b_flag should be 1"),  # set b_flag1 to 0
+        ((compressed_z2[0] | (1<<381), compressed_z2[1]), "a_flag should be 0"),  # set a_flag1 to 1
+        ((compressed_g2[0], compressed_z2[1] | (1<<383)), "a_flag2, b_flag2, and c_flag2 should always set to 0"),  # set c_flag2 to 1
+    ]
+)
+def test_decompress_G2_edge_case(z, error_message):
+    if error_message is None:
+        decompress_G2(z)
+    else:
+        with pytest.raises(ValueError, match=error_message):
+            decompress_G2(z)


### PR DESCRIPTION
### What was wrong?
Fix #108 

### How was it fixed?
Note: py_ecc doesn't provide APIs decompressed form deserialization, only compressed form deserialization.

1. Check if `c_flag is True`
2. If `b_flag` is True, check if `a_flag` is False and the value is 0.
3. For `decompress_G2`, check `c_flag2 == b_flag2 == a_flag2 == False`

#### Cute Animal Picture
🦩
