### PR TITLE
AggregateVerify accepts publc keys and messages as separate parameters, aligning README with it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ signatures = [bls_pop.Sign(key, message) for key, message in zip(private_keys, m
 agg_sig = bls_pop.Aggregate(signatures)
 
 # Verify aggregate signature with different messages
-assert bls_pop.AggregateVerify(zip(public_keys, messages), agg_sig)
+assert bls_pop.AggregateVerify(public_keys, messages, agg_sig)
 ```
 
 ## Developer Setup


### PR DESCRIPTION

### What was wrong?

The code in README.md would produce the following error:

````
Traceback (most recent call last):
  File "test.py", line 34, in <module>
    assert bls_pop.AggregateVerify(cls, BLSSignature(agg_sig))
TypeError: AggregateVerify() missing 1 required positional argument: 'signature'
````

### How was it fixed?

Because `AggregateVerify` expects a list of public keys and a list of messages as separate arguments, it has mistaken the supplied `agg_sig` as the list of messages and begs for the non-existing signature list. Updating document to match the code.

#### Cute Animal Picture

![e](https://wallpaperaccess.com/full/1137997.jpg)
