### PR TITLE
Extract `subgroup_check` from `signature_to_G2`

### DIFF
--- a/py_ecc/bls/ciphersuites.py
+++ b/py_ecc/bls/ciphersuites.py
@@ -40,7 +40,7 @@ from .g2_primitives import (
     G2_to_signature,
     pubkey_to_G1,
     signature_to_G2,
-    pubkey_subgroup_check,
+    subgroup_check,
     is_inf,
 )
 
@@ -112,9 +112,7 @@ class BaseG2Ciphersuite(abc.ABC):
         if is_inf(pubkey_point):
             return False
 
-        try:
-            pubkey_subgroup_check(pubkey_point)
-        except (ValidationError, ValueError, AssertionError):
+        if not subgroup_check(pubkey_point):
             return False
 
         return True
@@ -151,6 +149,8 @@ class BaseG2Ciphersuite(abc.ABC):
             # Procedure
             assert cls.KeyValidate(PK)
             signature_point = signature_to_G2(signature)
+            if not subgroup_check(signature_point):
+                return False
             final_exponentiation = final_exponentiate(
                 pairing(
                     signature_point,
@@ -207,6 +207,8 @@ class BaseG2Ciphersuite(abc.ABC):
 
             # Procedure
             signature_point = signature_to_G2(signature)
+            if not subgroup_check(signature_point):
+                return False
             aggregate = FQ12.one()
             for pk, message in zip(PKs, messages):
                 assert cls.KeyValidate(pk)

--- a/py_ecc/bls/g2_primitives.py
+++ b/py_ecc/bls/g2_primitives.py
@@ -2,10 +2,6 @@ from eth_typing import (
     BLSSignature,
     BLSPubkey,
 )
-from eth_utils import (
-    ValidationError,
-    encode_hex,
-)
 
 from py_ecc.optimized_bls12_381 import (
     is_inf,
@@ -44,10 +40,6 @@ def G2_to_signature(pt: G2Uncompressed) -> BLSSignature:
 def signature_to_G2(signature: BLSSignature) -> G2Uncompressed:
     p = G2Compressed((os2ip(signature[:48]), os2ip(signature[48:])))
     signature_point = decompress_G2(p)
-    if not subgroup_check(signature_point):
-        raise ValidationError(
-            'Signature (%s) is not a part of the E2 subgroup.' % encode_hex(signature)
-        )
     return signature_point
 
 
@@ -59,8 +51,3 @@ def G1_to_pubkey(pt: G1Uncompressed) -> BLSPubkey:
 def pubkey_to_G1(pubkey: BLSPubkey) -> G1Uncompressed:
     z = os2ip(pubkey)
     return decompress_G1(G1Compressed(z))
-
-
-def pubkey_subgroup_check(pt: G1Uncompressed) -> None:
-    if not subgroup_check(pt):
-        raise ValidationError('Pubkey is not a part of the E1 subgroup.')


### PR DESCRIPTION
### What was wrong?
`signature_to_G2` should be only for deserialization and decompression. 


### How was it fixed?
Extract `subgroup_check(signature_point)` from `signature_to_G2`.

#### Cute Animal Picture

🦐 
