### PR TITLE
replace asserts

### DIFF
--- a/newsfragments/142.internal.rst
+++ b/newsfragments/142.internal.rst
@@ -1,0 +1,1 @@
+Replace non-test instances of ``assert`` statments with better validation

--- a/py_ecc/bls12_381/bls12_381_curve.py
+++ b/py_ecc/bls12_381/bls12_381_curve.py
@@ -19,9 +19,11 @@ curve_order = (
 )
 
 # Curve order should be prime
-assert pow(2, curve_order, curve_order) == 2
+if not pow(2, curve_order, curve_order) == 2:
+    raise ValueError("Curve order is not prime")
 # Curve order should be a factor of field_modulus**12 - 1
-assert (field_modulus**12 - 1) % curve_order == 0
+if not (field_modulus**12 - 1) % curve_order == 0:
+    raise ValueError("Curve order is not a factor of field_modulus**12 - 1")
 
 # Curve is y**2 = x**3 + 4
 b = FQ(4)
@@ -73,8 +75,10 @@ def is_on_curve(pt: Point2D[Field], b: Field) -> bool:
     return y**2 - x**3 == b
 
 
-assert is_on_curve(G1, b)
-assert is_on_curve(G2, b2)
+if not is_on_curve(G1, b):
+    raise ValueError("Generator is not on curve")
+if not is_on_curve(G2, b2):
+    raise ValueError("Generator is not on twisted curve")
 
 
 # Elliptic curve doubling
@@ -102,7 +106,8 @@ def add(p1: Point2D[Field], p2: Point2D[Field]) -> Point2D[Field]:
         m = (y2 - y1) / (x2 - x1)
     newx = m**2 - x1 - x2
     newy = -m * newx + m * x1 - y1
-    assert newy == (-m * newx + m * x2 - y2)
+    if not newy == (-m * newx + m * x2 - y2):
+        raise ValueError("Point addition is incorrect")
     return (newx, newy)
 
 
@@ -151,4 +156,5 @@ def twist(pt: Point2D[FQP]) -> Point2D[FQ12]:
 
 G12 = twist(G2)
 # Check that the twist creates a point that is on the curve
-assert is_on_curve(G12, b12)
+if not is_on_curve(G12, b12):
+    raise ValueError("Twist creates a point not on curve")

--- a/py_ecc/bls12_381/bls12_381_pairing.py
+++ b/py_ecc/bls12_381/bls12_381_pairing.py
@@ -32,7 +32,8 @@ log_ate_loop_count = 62
 # Create a function representing the line between P1 and P2,
 # and evaluate it at T
 def linefunc(P1: Point2D[Field], P2: Point2D[Field], T: Point2D[Field]) -> Field:
-    assert P1 and P2 and T  # No points-at-infinity allowed, sorry
+    if not P1 and P2 and T:  # No points-at-infinity allowed, sorry
+        raise ValueError("Invalid input - no points-at-infinity allowed")
     x1, y1 = P1
     x2, y2 = P2
     xt, yt = T
@@ -62,16 +63,21 @@ negone, negtwo, negthree = (
 )
 
 
-assert linefunc(one, two, one) == FQ(0)
-assert linefunc(one, two, two) == FQ(0)
-assert linefunc(one, two, three) != FQ(0)
-assert linefunc(one, two, negthree) == FQ(0)
-assert linefunc(one, negone, one) == FQ(0)
-assert linefunc(one, negone, negone) == FQ(0)
-assert linefunc(one, negone, two) != FQ(0)
-assert linefunc(one, one, one) == FQ(0)
-assert linefunc(one, one, two) != FQ(0)
-assert linefunc(one, one, negtwo) == FQ(0)
+conditions = [
+    linefunc(one, two, one) == FQ(0),
+    linefunc(one, two, two) == FQ(0),
+    linefunc(one, two, three) != FQ(0),
+    linefunc(one, two, negthree) == FQ(0),
+    linefunc(one, negone, one) == FQ(0),
+    linefunc(one, negone, negone) == FQ(0),
+    linefunc(one, negone, two) != FQ(0),
+    linefunc(one, one, one) == FQ(0),
+    linefunc(one, one, two) != FQ(0),
+    linefunc(one, one, negtwo) == FQ(0),
+]
+
+if not all(conditions):
+    raise ValueError("Line function is inconsistent")
 
 
 # Main miller loop
@@ -100,8 +106,10 @@ def miller_loop(Q: Point2D[FQ12], P: Point2D[FQ12]) -> FQ12:
 
 # Pairing computation
 def pairing(Q: Point2D[FQ2], P: Point2D[FQ]) -> FQ12:
-    assert is_on_curve(Q, b2)
-    assert is_on_curve(P, b)
+    if not is_on_curve(Q, b2):
+        raise ValueError("Invalid input - point Q is not on the correct curve")
+    if not is_on_curve(P, b):
+        raise ValueError("Invalid input - point P is not on the correct curves")
     return miller_loop(twist(Q), cast_point_to_fq12(P))
 
 

--- a/py_ecc/bn128/bn128_curve.py
+++ b/py_ecc/bn128/bn128_curve.py
@@ -19,9 +19,11 @@ curve_order = (
 )
 
 # Curve order should be prime
-assert pow(2, curve_order, curve_order) == 2
+if not pow(2, curve_order, curve_order) == 2:
+    raise ValueError("Curve order is not prime")
 # Curve order should be a factor of field_modulus**12 - 1
-assert (field_modulus**12 - 1) % curve_order == 0
+if not (field_modulus**12 - 1) % curve_order == 0:
+    raise ValueError("Curve order is not a factor of field_modulus**12 - 1")
 
 # Curve is y**2 = x**3 + 3
 b = FQ(3)
@@ -66,8 +68,10 @@ def is_on_curve(pt: Point2D[Field], b: Field) -> bool:
     return y**2 - x**3 == b
 
 
-assert is_on_curve(G1, b)
-assert is_on_curve(G2, b2)
+if not is_on_curve(G1, b):
+    raise ValueError("G1 is not on the curve")
+if not is_on_curve(G2, b2):
+    raise ValueError("G2 is not on the curve")
 
 
 # Elliptic curve doubling
@@ -95,7 +99,8 @@ def add(p1: Point2D[Field], p2: Point2D[Field]) -> Point2D[Field]:
         m = (y2 - y1) / (x2 - x1)
     newx = m**2 - x1 - x2
     newy = -m * newx + m * x1 - y1
-    assert newy == (-m * newx + m * x2 - y2)
+    if not newy == (-m * newx + m * x2 - y2):
+        raise ValueError("Point addition is incorrect")
     return (newx, newy)
 
 
@@ -144,4 +149,5 @@ def twist(pt: Point2D[FQP]) -> Point2D[FQ12]:
 
 G12 = twist(G2)
 # Check that the twist creates a point that is on the curve
-assert is_on_curve(G12, b12)
+if not is_on_curve(G12, b12):
+    raise ValueError("Twist creates a point not on curve")

--- a/py_ecc/bn128/bn128_pairing.py
+++ b/py_ecc/bn128/bn128_pairing.py
@@ -32,7 +32,8 @@ log_ate_loop_count = 63
 # Create a function representing the line between P1 and P2,
 # and evaluate it at T
 def linefunc(P1: Point2D[Field], P2: Point2D[Field], T: Point2D[Field]) -> Field:
-    assert P1 and P2 and T  # No points-at-infinity allowed, sorry
+    if not P1 and P2 and T:  # No points-at-infinity allowed, sorry
+        raise ValueError("Invalid input - no points-at-infinity allowed")
     x1, y1 = P1
     x2, y2 = P2
     xt, yt = T
@@ -63,16 +64,21 @@ negone, negtwo, negthree = (
 )
 
 
-assert linefunc(one, two, one) == FQ(0)
-assert linefunc(one, two, two) == FQ(0)
-assert linefunc(one, two, three) != FQ(0)
-assert linefunc(one, two, negthree) == FQ(0)
-assert linefunc(one, negone, one) == FQ(0)
-assert linefunc(one, negone, negone) == FQ(0)
-assert linefunc(one, negone, two) != FQ(0)
-assert linefunc(one, one, one) == FQ(0)
-assert linefunc(one, one, two) != FQ(0)
-assert linefunc(one, one, negtwo) == FQ(0)
+conditions = [
+    linefunc(one, two, one) == FQ(0),
+    linefunc(one, two, two) == FQ(0),
+    linefunc(one, two, three) != FQ(0),
+    linefunc(one, two, negthree) == FQ(0),
+    linefunc(one, negone, one) == FQ(0),
+    linefunc(one, negone, negone) == FQ(0),
+    linefunc(one, negone, two) != FQ(0),
+    linefunc(one, one, one) == FQ(0),
+    linefunc(one, one, two) != FQ(0),
+    linefunc(one, one, negtwo) == FQ(0),
+]
+
+if not all(conditions):
+    raise ValueError("Line function is inconsistent")
 
 
 # Main miller loop
@@ -101,8 +107,10 @@ def miller_loop(Q: Point2D[FQ12], P: Point2D[FQ12]) -> FQ12:
 
 # Pairing computation
 def pairing(Q: Point2D[FQ2], P: Point2D[FQ]) -> FQ12:
-    assert is_on_curve(Q, b2)
-    assert is_on_curve(P, b)
+    if not is_on_curve(Q, b2):
+        raise ValueError("Invalid input - point Q is not on the correct curve")
+    if not is_on_curve(P, b):
+        raise ValueError("Invalid input - point P is not on the correct curves")
     return miller_loop(twist(Q), cast_point_to_fq12(P))
 
 

--- a/py_ecc/optimized_bls12_381/optimized_curve.py
+++ b/py_ecc/optimized_bls12_381/optimized_curve.py
@@ -19,9 +19,11 @@ curve_order = (
 )
 
 # Curve order should be prime
-assert pow(2, curve_order, curve_order) == 2
+if not pow(2, curve_order, curve_order) == 2:
+    raise ValueError("Curve order is not prime")
 # Curve order should be a factor of field_modulus**12 - 1
-assert (field_modulus**12 - 1) % curve_order == 0
+if not (field_modulus**12 - 1) % curve_order == 0:
+    raise ValueError("Curve order is not a factor of field_modulus**12 - 1")
 
 # Curve is y**2 = x**3 + 4
 b = FQ(4)
@@ -75,8 +77,10 @@ def is_on_curve(pt: Optimized_Point3D[Optimized_Field], b: Optimized_Field) -> b
     return y**2 * z - x**3 == b * z**3
 
 
-assert is_on_curve(G1, b)
-assert is_on_curve(G2, b2)
+if not is_on_curve(G1, b):
+    raise ValueError("Generator is not on curve")
+if not is_on_curve(G2, b2):
+    raise ValueError("Generator is not on twisted curve")
 
 
 # Elliptic curve doubling
@@ -178,4 +182,5 @@ def twist(pt: Optimized_Point3D[FQP]) -> Optimized_Point3D[FQ12]:
 
 # Check that the twist creates a point that is on the curve
 G12 = twist(G2)
-assert is_on_curve(G12, b12)
+if not is_on_curve(G12, b12):
+    raise ValueError("Twist creates a point not on curve")

--- a/py_ecc/optimized_bls12_381/optimized_pairing.py
+++ b/py_ecc/optimized_bls12_381/optimized_pairing.py
@@ -97,7 +97,10 @@ pseudo_binary_encoding = [
 ]
 
 
-assert sum([e * 2**i for i, e in enumerate(pseudo_binary_encoding)]) == ate_loop_count
+if not (
+    sum([e * 2**i for i, e in enumerate(pseudo_binary_encoding)]) == ate_loop_count
+):
+    raise ValueError("Pseudo binary encoding is incorrect")
 
 
 def normalize1(
@@ -159,16 +162,21 @@ negone, negtwo, negthree = (
 )
 
 
-assert linefunc(one, two, one)[0] == FQ(0)
-assert linefunc(one, two, two)[0] == FQ(0)
-assert linefunc(one, two, three)[0] != FQ(0)
-assert linefunc(one, two, negthree)[0] == FQ(0)
-assert linefunc(one, negone, one)[0] == FQ(0)
-assert linefunc(one, negone, negone)[0] == FQ(0)
-assert linefunc(one, negone, two)[0] != FQ(0)
-assert linefunc(one, one, one)[0] == FQ(0)
-assert linefunc(one, one, two)[0] != FQ(0)
-assert linefunc(one, one, negtwo)[0] == FQ(0)
+conditions = [
+    linefunc(one, two, one)[0] == FQ(0),
+    linefunc(one, two, two)[0] == FQ(0),
+    linefunc(one, two, three)[0] != FQ(0),
+    linefunc(one, two, negthree)[0] == FQ(0),
+    linefunc(one, negone, one)[0] == FQ(0),
+    linefunc(one, negone, negone)[0] == FQ(0),
+    linefunc(one, negone, two)[0] != FQ(0),
+    linefunc(one, one, one)[0] == FQ(0),
+    linefunc(one, one, two)[0] != FQ(0),
+    linefunc(one, one, negtwo)[0] == FQ(0),
+]
+
+if not all(conditions):
+    raise ValueError("Line function is inconsistent")
 
 
 # Main miller loop
@@ -215,8 +223,10 @@ def miller_loop(
 def pairing(
     Q: Optimized_Point3D[FQ2], P: Optimized_Point3D[FQ], final_exponentiate: bool = True
 ) -> FQ12:
-    assert is_on_curve(Q, b2)
-    assert is_on_curve(P, b)
+    if not is_on_curve(Q, b2):
+        raise ValueError("Invalid input - point Q is not on the correct curve")
+    if not is_on_curve(P, b):
+        raise ValueError("Invalid input - point P is not on the correct curves")
     if P[-1] == (P[-1].zero()) or Q[-1] == (Q[-1].zero()):
         return FQ12.one()
     return miller_loop(Q, P, final_exponentiate=final_exponentiate)

--- a/py_ecc/optimized_bn128/optimized_curve.py
+++ b/py_ecc/optimized_bn128/optimized_curve.py
@@ -19,9 +19,11 @@ curve_order = (
 )
 
 # Curve order should be prime
-assert pow(2, curve_order, curve_order) == 2
+if not pow(2, curve_order, curve_order) == 2:
+    raise ValueError("Curve order is not prime")
 # Curve order should be a factor of field_modulus**12 - 1
-assert (field_modulus**12 - 1) % curve_order == 0
+if not (field_modulus**12 - 1) % curve_order == 0:
+    raise ValueError("Curve order is not a factor of field_modulus**12 - 1")
 
 # Curve is y**2 = x**3 + 3
 b = FQ(3)
@@ -67,8 +69,10 @@ def is_on_curve(pt: Optimized_Point3D[Optimized_Field], b: Optimized_Field) -> b
     return y**2 * z - x**3 == b * z**3
 
 
-assert is_on_curve(G1, b)
-assert is_on_curve(G2, b2)
+if not is_on_curve(G1, b):
+    raise ValueError("Generator is not on curve")
+if not is_on_curve(G2, b2):
+    raise ValueError("Generator is not on twisted curve")
 
 
 # Elliptic curve doubling
@@ -170,4 +174,5 @@ def twist(pt: Optimized_Point3D[FQP]) -> Optimized_Point3D[FQ12]:
 
 # Check that the twist creates a point that is on the curve
 G12 = twist(G2)
-assert is_on_curve(G12, b12)
+if not is_on_curve(G12, b12):
+    raise ValueError("Twist creates a point not on curve")

--- a/py_ecc/optimized_bn128/optimized_pairing.py
+++ b/py_ecc/optimized_bn128/optimized_pairing.py
@@ -99,7 +99,10 @@ pseudo_binary_encoding = [
 ]
 
 
-assert sum([e * 2**i for i, e in enumerate(pseudo_binary_encoding)]) == ate_loop_count
+if not (
+    sum([e * 2**i for i, e in enumerate(pseudo_binary_encoding)]) == ate_loop_count
+):
+    raise ValueError("Pseudo binary encoding is incorrect")
 
 
 def normalize1(
@@ -160,17 +163,21 @@ negone, negtwo, negthree = (
     multiply(G1, curve_order - 3),
 )
 
+conditions = [
+    linefunc(one, two, one)[0] == FQ(0),
+    linefunc(one, two, two)[0] == FQ(0),
+    linefunc(one, two, three)[0] != FQ(0),
+    linefunc(one, two, negthree)[0] == FQ(0),
+    linefunc(one, negone, one)[0] == FQ(0),
+    linefunc(one, negone, negone)[0] == FQ(0),
+    linefunc(one, negone, two)[0] != FQ(0),
+    linefunc(one, one, one)[0] == FQ(0),
+    linefunc(one, one, two)[0] != FQ(0),
+    linefunc(one, one, negtwo)[0] == FQ(0),
+]
 
-assert linefunc(one, two, one)[0] == FQ(0)
-assert linefunc(one, two, two)[0] == FQ(0)
-assert linefunc(one, two, three)[0] != FQ(0)
-assert linefunc(one, two, negthree)[0] == FQ(0)
-assert linefunc(one, negone, one)[0] == FQ(0)
-assert linefunc(one, negone, negone)[0] == FQ(0)
-assert linefunc(one, negone, two)[0] != FQ(0)
-assert linefunc(one, one, one)[0] == FQ(0)
-assert linefunc(one, one, two)[0] != FQ(0)
-assert linefunc(one, one, negtwo)[0] == FQ(0)
+if not all(conditions):
+    raise ValueError("Line function is inconsistent")
 
 
 # Main miller loop
@@ -221,8 +228,10 @@ def miller_loop(
 def pairing(
     Q: Optimized_Point3D[FQ2], P: Optimized_Point3D[FQ], final_exponentiate: bool = True
 ) -> FQ12:
-    assert is_on_curve(Q, b2)
-    assert is_on_curve(P, b)
+    if not is_on_curve(Q, b2):
+        raise ValueError("Invalid input - point Q is not on the correct curve")
+    if not is_on_curve(P, b):
+        raise ValueError("Invalid input - point P is not on the correct curves")
     if P[-1] == (P[-1].zero()) or Q[-1] == (Q[-1].zero()):
         return FQ12.one()
     return miller_loop(


### PR DESCRIPTION
### What was wrong?

Lots of `assert` statements used in non-test files.

Related to Issue #135

### How was it fixed?

Replace `assert`s with `if`s or whatever is appropriate, add error messages.

Where the asserts would have raised `AssertionError`s, `ValueError` seems more appropriate for what's been checked. 

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/py_ecc/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/cd53b8c2-2305-4c99-b91a-3a81ea633013)
