### PR TITLE
Update typing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,13 +43,14 @@ repos:
     -   id: mdformat
         additional_dependencies:
         -   mdformat-gfm
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+-   repo: local
     hooks:
-    -   id: mypy
-        # mypy checks are turned off for now, re-enable as typing is updated
-        # see issue #131
-        exclude: 'tests/|py_ecc/'
+    -   id: mypy-local
+        name: run mypy with all dev dependencies present
+        entry: python -m mypy -p py_ecc
+        language: system
+        always_run: true
+        pass_filenames: false
 -   repo: https://github.com/PrincetonUniversity/blocklint
     rev: v0.2.5
     hooks:

--- a/newsfragments/143.breaking.rst
+++ b/newsfragments/143.breaking.rst
@@ -1,0 +1,1 @@
+Updated typing across the library

--- a/newsfragments/143.feature.rst
+++ b/newsfragments/143.feature.rst
@@ -1,0 +1,1 @@
+Added ``__lt__`` to ``FQ`` classes

--- a/py_ecc/bls/ciphersuites.py
+++ b/py_ecc/bls/ciphersuites.py
@@ -1,4 +1,7 @@
-import abc
+from abc import (
+    ABC,
+    abstractmethod,
+)
 from hashlib import (
     sha256,
 )
@@ -52,7 +55,7 @@ from .hash_to_curve import (
 )
 
 
-class BaseG2Ciphersuite(abc.ABC):
+class BaseG2Ciphersuite(ABC):
     DST = b""
     xmd_hash_function = sha256
 
@@ -250,7 +253,8 @@ class BaseG2Ciphersuite(abc.ABC):
     def Verify(cls, PK: BLSPubkey, message: bytes, signature: BLSSignature) -> bool:
         return cls._CoreVerify(PK, message, signature, cls.DST)
 
-    @abc.abstractclassmethod
+    @classmethod
+    @abstractmethod
     def AggregateVerify(
         cls,
         PKs: Sequence[BLSPubkey],

--- a/py_ecc/bls/g2_primitives.py
+++ b/py_ecc/bls/g2_primitives.py
@@ -9,6 +9,7 @@ from py_ecc.optimized_bls12_381 import (
     multiply,
 )
 from py_ecc.typing import (
+    Optimized_Field,
     Optimized_Point3D,
 )
 
@@ -30,7 +31,7 @@ from .typing import (
 )
 
 
-def subgroup_check(P: Optimized_Point3D) -> bool:
+def subgroup_check(P: Optimized_Point3D[Optimized_Field]) -> bool:
     return is_inf(multiply(P, curve_order))
 
 

--- a/py_ecc/bls/point_compression.py
+++ b/py_ecc/bls/point_compression.py
@@ -162,14 +162,14 @@ def compress_G2(pt: G2Uncompressed) -> G2Compressed:
     y_re, y_im = y.coeffs
     # Record the leftmost bit of y_im to the a_flag1
     # If y_im happens to be zero, then use the bit of y_re
-    a_flag1 = (y_im * 2) // q if y_im > 0 else (y_re * 2) // q
+    a_flag1 = (int(y_im) * 2) // q if y_im > 0 else (int(y_re) * 2) // q
 
     # Imaginary part of x goes to z1, real part goes to z2
     # c_flag1 = 1, b_flag1 = 0
     z1 = x_im + a_flag1 * POW_2_381 + POW_2_383
     # a_flag2 = b_flag2 = c_flag2 = 0
     z2 = x_re
-    return G2Compressed((z1, z2))
+    return G2Compressed((int(z1), int(z2)))
 
 
 def decompress_G2(p: G2Compressed) -> G2Uncompressed:
@@ -216,8 +216,8 @@ def decompress_G2(p: G2Compressed) -> G2Uncompressed:
     # Choose the y whose leftmost bit of the imaginary part is equal to the a_flag1
     # If y_im happens to be zero, then use the bit of y_re
     y_re, y_im = y.coeffs
-    if (y_im > 0 and (y_im * 2) // q != int(a_flag1)) or (
-        y_im == 0 and (y_re * 2) // q != int(a_flag1)
+    if (y_im > 0 and (int(y_im) * 2) // q != int(a_flag1)) or (
+        y_im == 0 and (int(y_re) * 2) // q != int(a_flag1)
     ):
         y = FQ2((y * -1).coeffs)
 

--- a/py_ecc/bls12_381/bls12_381_curve.py
+++ b/py_ecc/bls12_381/bls12_381_curve.py
@@ -69,7 +69,7 @@ def is_inf(pt: GeneralPoint[Field]) -> bool:
 
 # Check that a point is on the curve defined by y**2 == x**3 + b
 def is_on_curve(pt: Point2D[Field], b: Field) -> bool:
-    if is_inf(pt):
+    if is_inf(pt) or pt is None:
         return True
     x, y = pt
     return y**2 - x**3 == b
@@ -83,7 +83,7 @@ if not is_on_curve(G2, b2):
 
 # Elliptic curve doubling
 def double(pt: Point2D[Field]) -> Point2D[Field]:
-    if is_inf(pt):
+    if is_inf(pt) or pt is None:
         return pt
     x, y = pt
     m = 3 * x**2 / (2 * y)

--- a/py_ecc/bls12_381/bls12_381_pairing.py
+++ b/py_ecc/bls12_381/bls12_381_pairing.py
@@ -32,7 +32,7 @@ log_ate_loop_count = 62
 # Create a function representing the line between P1 and P2,
 # and evaluate it at T
 def linefunc(P1: Point2D[Field], P2: Point2D[Field], T: Point2D[Field]) -> Field:
-    if not P1 and P2 and T:  # No points-at-infinity allowed, sorry
+    if P1 is None or P2 is None or T is None:  # No points-at-infinity allowed, sorry
         raise ValueError("Invalid input - no points-at-infinity allowed")
     x1, y1 = P1
     x2, y2 = P2
@@ -84,7 +84,7 @@ if not all(conditions):
 def miller_loop(Q: Point2D[FQ12], P: Point2D[FQ12]) -> FQ12:
     if Q is None or P is None:
         return FQ12.one()
-    R = Q  # type: Point2D[FQ12]
+    R: Point2D[FQ12] = Q
     f = FQ12.one()
     for i in range(log_ate_loop_count, -1, -1):
         f = f * f * linefunc(R, R, P)

--- a/py_ecc/bn128/bn128_curve.py
+++ b/py_ecc/bn128/bn128_curve.py
@@ -62,7 +62,7 @@ def is_inf(pt: GeneralPoint[Field]) -> bool:
 
 # Check that a point is on the curve defined by y**2 == x**3 + b
 def is_on_curve(pt: Point2D[Field], b: Field) -> bool:
-    if is_inf(pt):
+    if is_inf(pt) or pt is None:
         return True
     x, y = pt
     return y**2 - x**3 == b
@@ -76,7 +76,7 @@ if not is_on_curve(G2, b2):
 
 # Elliptic curve doubling
 def double(pt: Point2D[Field]) -> Point2D[Field]:
-    if is_inf(pt):
+    if is_inf(pt) or pt is None:
         return pt
     x, y = pt
     m = 3 * x**2 / (2 * y)

--- a/py_ecc/bn128/bn128_pairing.py
+++ b/py_ecc/bn128/bn128_pairing.py
@@ -32,7 +32,7 @@ log_ate_loop_count = 63
 # Create a function representing the line between P1 and P2,
 # and evaluate it at T
 def linefunc(P1: Point2D[Field], P2: Point2D[Field], T: Point2D[Field]) -> Field:
-    if not P1 and P2 and T:  # No points-at-infinity allowed, sorry
+    if P1 is None or P2 is None or T is None:  # No points-at-infinity allowed, sorry
         raise ValueError("Invalid input - no points-at-infinity allowed")
     x1, y1 = P1
     x2, y2 = P2
@@ -85,7 +85,7 @@ if not all(conditions):
 def miller_loop(Q: Point2D[FQ12], P: Point2D[FQ12]) -> FQ12:
     if Q is None or P is None:
         return FQ12.one()
-    R = Q  # type: Point2D[FQ12]
+    R: Point2D[FQ12] = Q
     f = FQ12.one()
     for i in range(log_ate_loop_count, -1, -1):
         f = f * f * linefunc(R, R, P)

--- a/py_ecc/fields/field_elements.py
+++ b/py_ecc/fields/field_elements.py
@@ -266,15 +266,18 @@ class FQP:
                 f"but got object of type {type(other)}"
             )
 
-    def __rmul__(self: T_FQP, other: Union[int, T_FQP]) -> T_FQP:
+    def __rmul__(self: T_FQP, other: Union[int, T_FQ, T_FQP]) -> T_FQP:
         return self * other
 
-    def __div__(self: T_FQP, other: Union[int, T_FQP]) -> T_FQP:
-        if isinstance(other, int):
+    def __div__(self: T_FQP, other: Union[int, T_FQ, T_FQP]) -> T_FQP:
+        if isinstance(other, int_types_or_FQ):
             return type(self)(
-                [c / other if isinstance(c, FQ) else c // other for c in self.coeffs]
+                [
+                    c / other if isinstance(c, FQ) else c // int(other)
+                    for c in self.coeffs
+                ]
             )
-        elif isinstance(other, FQP):
+        elif isinstance(other, type(self)):
             return self * other.inv()
         else:
             raise TypeError(
@@ -282,7 +285,7 @@ class FQP:
                 f"but got object of type {type(other)}"
             )
 
-    def __truediv__(self: T_FQP, other: Union[int, T_FQP]) -> T_FQP:
+    def __truediv__(self: T_FQP, other: Union[int, T_FQ, T_FQP]) -> T_FQP:
         return self.__div__(other)
 
     def __pow__(self: T_FQP, other: int) -> T_FQP:

--- a/py_ecc/fields/field_elements.py
+++ b/py_ecc/fields/field_elements.py
@@ -1,11 +1,10 @@
 from functools import (
     total_ordering,
 )
-from typing import (  # noqa: F401
+from typing import (
     TYPE_CHECKING,
     Any,
     List,
-    Optional,
     Sequence,
     Tuple,
     Type,
@@ -21,7 +20,7 @@ from py_ecc.utils import (
 )
 
 if TYPE_CHECKING:
-    from py_ecc.typing import (  # noqa: F401
+    from py_ecc.typing import (
         FQ2_modulus_coeffs_type,
         FQ12_modulus_coeffs_type,
     )

--- a/py_ecc/fields/field_properties.py
+++ b/py_ecc/fields/field_properties.py
@@ -5,7 +5,7 @@ from typing import (
 )
 
 if TYPE_CHECKING:
-    from py_ecc.typing import (  # noqa: F401
+    from py_ecc.typing import (
         FQ2_modulus_coeffs_type,
         FQ12_modulus_coeffs_type,
     )

--- a/py_ecc/fields/field_properties.py
+++ b/py_ecc/fields/field_properties.py
@@ -19,7 +19,7 @@ class Curve_Field_Properties(TypedDict):
 
 Field_Properties = Dict[str, Curve_Field_Properties]
 
-field_properties = {
+field_properties: Field_Properties = {
     "bn128": {
         "field_modulus": 21888242871839275222246405745257275088696311157297823662689037894645226208583,  # noqa: E501
         "fq2_modulus_coeffs": (1, 0),
@@ -30,4 +30,4 @@ field_properties = {
         "fq2_modulus_coeffs": (1, 0),
         "fq12_modulus_coeffs": (2, 0, 0, 0, 0, 0, -2, 0, 0, 0, 0, 0),  # Implied + [1]
     },
-}  # type: Field_Properties
+}

--- a/py_ecc/fields/optimized_field_elements.py
+++ b/py_ecc/fields/optimized_field_elements.py
@@ -20,7 +20,7 @@ from py_ecc.utils import (
 )
 
 if TYPE_CHECKING:
-    from py_ecc.typing import (  # noqa: F401
+    from py_ecc.typing import (
         FQ2_modulus_coeffs_type,
         FQ12_modulus_coeffs_type,
     )
@@ -373,7 +373,7 @@ class FQP:
     def __repr__(self) -> str:
         return repr(self.coeffs)
 
-    def __eq__(self: T_FQP, other: T_FQP) -> bool:  # type: ignore # https://github.com/python/mypy/issues/2783 # noqa: E501
+    def __eq__(self: T_FQP, other: Any) -> bool:
         if not isinstance(other, type(self)):
             raise TypeError(
                 f"Expected an FQP object, but got object of type {type(other)}"
@@ -384,7 +384,7 @@ class FQP:
                 return False
         return True
 
-    def __ne__(self: T_FQP, other: T_FQP) -> bool:  # type: ignore # https://github.com/python/mypy/issues/2783 # noqa: E501
+    def __ne__(self: T_FQP, other: Any) -> bool:
         return not self == other
 
     def __neg__(self: T_FQP) -> T_FQP:

--- a/py_ecc/fields/optimized_field_elements.py
+++ b/py_ecc/fields/optimized_field_elements.py
@@ -1,5 +1,6 @@
 from functools import (
     cached_property,
+    total_ordering,
 )
 from typing import (
     TYPE_CHECKING,
@@ -31,10 +32,10 @@ T_FQ = TypeVar("T_FQ", bound="FQ")
 T_FQP = TypeVar("T_FQP", bound="FQP")
 T_FQ2 = TypeVar("T_FQ2", bound="FQ2")
 T_FQ12 = TypeVar("T_FQ12", bound="FQ12")
-IntOrFQ = Union[int, T_FQ]
+IntOrFQ = Union[int, "FQ"]
 
 
-def mod_int(x: IntOrFQ[T_FQ], n: int) -> int:
+def mod_int(x: IntOrFQ, n: int) -> int:
     if isinstance(x, int):
         return x % n
     elif isinstance(x, FQ):
@@ -43,6 +44,7 @@ def mod_int(x: IntOrFQ[T_FQ], n: int) -> int:
         raise TypeError(f"Only int and T_FQ types are accepted: got {type(x)}")
 
 
+@total_ordering
 class FQ:
     """
     A class for field elements in FQ. Wrap a number in this class,
@@ -52,7 +54,7 @@ class FQ:
     n: int
     field_modulus: int
 
-    def __init__(self: T_FQ, val: IntOrFQ[T_FQ]) -> None:
+    def __init__(self: T_FQ, val: IntOrFQ) -> None:
         if not hasattr(self, "field_modulus"):
             raise AttributeError("Field Modulus hasn't been specified")
 
@@ -65,7 +67,7 @@ class FQ:
                 f"Expected an int or FQ object, but got object of type {type(val)}"
             )
 
-    def __add__(self: T_FQ, other: IntOrFQ[T_FQ]) -> T_FQ:
+    def __add__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         if isinstance(other, FQ):
             on = other.n
         elif isinstance(other, int):
@@ -77,7 +79,7 @@ class FQ:
 
         return type(self)((self.n + on) % self.field_modulus)
 
-    def __mul__(self: T_FQ, other: IntOrFQ[T_FQ]) -> T_FQ:
+    def __mul__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         if isinstance(other, FQ):
             on = other.n
         elif isinstance(other, int):
@@ -89,13 +91,13 @@ class FQ:
 
         return type(self)((self.n * on) % self.field_modulus)
 
-    def __rmul__(self: T_FQ, other: IntOrFQ[T_FQ]) -> T_FQ:
+    def __rmul__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         return self * other
 
-    def __radd__(self: T_FQ, other: IntOrFQ[T_FQ]) -> T_FQ:
+    def __radd__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         return self + other
 
-    def __rsub__(self: T_FQ, other: IntOrFQ[T_FQ]) -> T_FQ:
+    def __rsub__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         if isinstance(other, FQ):
             on = other.n
         elif isinstance(other, int):
@@ -107,7 +109,7 @@ class FQ:
 
         return type(self)((on - self.n) % self.field_modulus)
 
-    def __sub__(self: T_FQ, other: IntOrFQ[T_FQ]) -> T_FQ:
+    def __sub__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         if isinstance(other, FQ):
             on = other.n
         elif isinstance(other, int):
@@ -119,10 +121,10 @@ class FQ:
 
         return type(self)((self.n - on) % self.field_modulus)
 
-    def __mod__(self: T_FQ, other: IntOrFQ[T_FQ]) -> T_FQ:
+    def __mod__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         raise NotImplementedError("Modulo Operation not yet supported by fields")
 
-    def __div__(self: T_FQ, other: IntOrFQ[T_FQ]) -> T_FQ:
+    def __div__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         if isinstance(other, FQ):
             on = other.n
         elif isinstance(other, int):
@@ -136,10 +138,10 @@ class FQ:
             self.n * prime_field_inv(on, self.field_modulus) % self.field_modulus
         )
 
-    def __truediv__(self: T_FQ, other: IntOrFQ[T_FQ]) -> T_FQ:
+    def __truediv__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         return self.__div__(other)
 
-    def __rdiv__(self: T_FQ, other: IntOrFQ[T_FQ]) -> T_FQ:
+    def __rdiv__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         if isinstance(other, FQ):
             on = other.n
         elif isinstance(other, int):
@@ -153,7 +155,7 @@ class FQ:
             prime_field_inv(self.n, self.field_modulus) * on % self.field_modulus
         )
 
-    def __rtruediv__(self: T_FQ, other: IntOrFQ[T_FQ]) -> T_FQ:
+    def __rtruediv__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         return self.__rdiv__(other)
 
     def __pow__(self: T_FQ, other: int) -> T_FQ:
@@ -187,6 +189,17 @@ class FQ:
 
     def __int__(self: T_FQ) -> int:
         return self.n
+
+    def __lt__(self: T_FQ, other: IntOrFQ) -> bool:
+        if isinstance(other, FQ):
+            on = other.n
+        elif isinstance(other, int):
+            on = other
+        else:
+            raise TypeError(
+                f"Expected an int or FQ object, but got object of type {type(other)}"
+            )
+        return self.n < on
 
     @cached_property
     def sgn0(self: T_FQ) -> int:
@@ -355,7 +368,7 @@ class FQP:
             nm = [x % self.field_modulus for x in nm]
             new = [int(x) % self.field_modulus for x in new]
             lm, low, hm, high = nm, new, lm, low
-        return type(self)(lm[: self.degree]) / low[0]
+        return type(self)(lm[: self.degree]) / int(low[0])
 
     def __repr__(self) -> str:
         return repr(self.coeffs)
@@ -412,7 +425,7 @@ class FQ2(FQP):
     degree: int = 2
     FQ2_MODULUS_COEFFS: "FQ2_modulus_coeffs_type"
 
-    def __init__(self, coeffs: Sequence[IntOrFQ[T_FQ]]) -> None:
+    def __init__(self, coeffs: Sequence[IntOrFQ]) -> None:
         if not hasattr(self, "FQ2_MODULUS_COEFFS"):
             raise AttributeError("FQ2 Modulus Coeffs haven't been specified")
 
@@ -445,7 +458,7 @@ class FQ12(FQP):
     degree: int = 12
     FQ12_MODULUS_COEFFS: "FQ12_modulus_coeffs_type"
 
-    def __init__(self, coeffs: Sequence[IntOrFQ[T_FQ]]) -> None:
+    def __init__(self, coeffs: Sequence[IntOrFQ]) -> None:
         if not hasattr(self, "FQ12_MODULUS_COEFFS"):
             raise AttributeError("FQ12 Modulus Coeffs haven't been specified")
 

--- a/py_ecc/optimized_bls12_381/optimized_pairing.py
+++ b/py_ecc/optimized_bls12_381/optimized_pairing.py
@@ -187,7 +187,7 @@ def miller_loop(
         return FQ12.one()
     cast_P = cast_point_to_fq12(P)
     twist_R = twist_Q = twist(Q)
-    R = Q  # type: Optimized_Point3D[FQ2]
+    R: Optimized_Point3D[FQ2] = Q
     f_num, f_den = FQ12.one(), FQ12.one()
     # for i in range(log_ate_loop_count, -1, -1):
     for v in pseudo_binary_encoding[62::-1]:

--- a/py_ecc/optimized_bls12_381/optimized_pairing.py
+++ b/py_ecc/optimized_bls12_381/optimized_pairing.py
@@ -237,7 +237,7 @@ exptable = [FQ12([0] * i + [1] + [0] * (11 - i)) ** field_modulus for i in range
 
 def exp_by_p(x: FQ12) -> FQ12:
     return sum(
-        (table_entry * coeff for table_entry, coeff in zip(exptable, x.coeffs)),
+        (table_entry * int(coeff) for table_entry, coeff in zip(exptable, x.coeffs)),
         FQ12.zero(),
     )
 

--- a/py_ecc/optimized_bn128/optimized_pairing.py
+++ b/py_ecc/optimized_bn128/optimized_pairing.py
@@ -188,7 +188,7 @@ def miller_loop(
 ) -> FQ12:
     if Q is None or P is None:
         return FQ12.one()
-    R = Q  # type: Optimized_Point3D[FQ12]
+    R: Optimized_Point3D[FQ12] = Q
     f_num, f_den = FQ12.one(), FQ12.one()
     # for i in range(log_ate_loop_count, -1, -1):
     for v in pseudo_binary_encoding[63::-1]:

--- a/py_ecc/secp256k1/secp256k1.py
+++ b/py_ecc/secp256k1/secp256k1.py
@@ -1,6 +1,5 @@
 import hashlib
 import hmac
-import sys
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -9,21 +8,17 @@ from typing import (
 )
 
 if TYPE_CHECKING:
-    from py_ecc.typing import (  # noqa: F401
+    from py_ecc.typing import (
         PlainPoint2D,
         PlainPoint3D,
     )
 
 
-if sys.version_info.major == 2:
-    safe_ord = ord
-else:
-
-    def safe_ord(value: Any) -> int:
-        if isinstance(value, int):
-            return value
-        else:
-            return ord(value)
+def safe_ord(value: Any) -> int:
+    if isinstance(value, int):
+        return value
+    else:
+        return ord(value)
 
 
 # Elliptic curve parameters (secp256k1)
@@ -39,7 +34,7 @@ G = cast("PlainPoint2D", (Gx, Gy))
 def bytes_to_int(x: bytes) -> int:
     o = 0
     for b in x:
-        o = (o << 8) + safe_ord(b)  # type: ignore
+        o = (o << 8) + safe_ord(b)
     return o
 
 
@@ -140,7 +135,7 @@ def from_jacobian(p: "PlainPoint3D") -> "PlainPoint2D":
     return cast("PlainPoint2D", ((p[0] * z**2) % P, (p[1] * z**3) % P))
 
 
-def jacobian_multiply(a: "PlainPoint3D", n: int) -> "PlainPoint3D":  # type: ignore
+def jacobian_multiply(a: "PlainPoint3D", n: int) -> "PlainPoint3D":
     """
     Multiply a point in Jacobian coordinates by an integer and return the result.
 
@@ -162,6 +157,7 @@ def jacobian_multiply(a: "PlainPoint3D", n: int) -> "PlainPoint3D":  # type: ign
         return jacobian_double(jacobian_multiply(a, n // 2))
     if (n % 2) == 1:
         return jacobian_add(jacobian_double(jacobian_multiply(a, n // 2)), a)
+    raise ValueError("Unexpected case in jacobian_multiply: This should never happen.")
 
 
 def multiply(a: "PlainPoint2D", n: int) -> "PlainPoint2D":

--- a/py_ecc/secp256k1/secp256k1.py
+++ b/py_ecc/secp256k1/secp256k1.py
@@ -19,7 +19,7 @@ if sys.version_info.major == 2:
     safe_ord = ord
 else:
 
-    def safe_ord(value: Any) -> int:  # type: ignore
+    def safe_ord(value: Any) -> int:
         if isinstance(value, int):
             return value
         else:

--- a/py_ecc/utils.py
+++ b/py_ecc/utils.py
@@ -7,10 +7,10 @@ from typing import (
 )
 
 if TYPE_CHECKING:
-    from py_ecc.fields.field_elements import (  # noqa: F401
+    from py_ecc.fields.field_elements import (
         FQ,
     )
-    from py_ecc.fields.optimized_field_elements import (  # noqa: F401
+    from py_ecc.fields.optimized_field_elements import (
         FQ as optimized_FQ,
     )
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ extras_require = {
         "build>=0.9.0",
         "bumpversion>=0.5.3",
         "ipython",
+        "mypy==1.10.0",
         "pre-commit>=3.4.0",
         "tox>=4.0.0",
         "twine",

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ allowlist_externals=make,pre-commit
 
 [testenv:py{38,39,310,311,312}-lint]
 deps=pre-commit
+extras=dev
 commands=
     pre-commit install
     pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
### What was wrong?

mypy checks had been turned off.

Closes #131 

### How was it fixed?

Move mypy checks to run locally, fix errors

The largest changes are within `field_elements` and `optimized_field_elements`, where the `IntOrFQ` type changed from using a generic to a regular type (`FQ` instead of `T_FQ`). I was unable to resolve the use of the generic `T_FQ` within the `FQP` class when it was bound to the `FQ` class, and since it was only used within functions, changing to `FQ` seems to work fine.

The change had some downstream effects, which were resolved either by `int`ing `IntOrFQ` variables (`FQ` defines `__int__` so that this is handled correctly, or by defining the `__lt__`. 

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/py_ecc/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/cdfa45a7-7fc1-451c-8f6f-9d3ef9a37edc)
