### PR TITLE
Lazy-load submodules

### DIFF
--- a/newsfragments/135.performance.rst
+++ b/newsfragments/135.performance.rst
@@ -1,0 +1,1 @@
+Lazy-load submodules to reduce initial import time

--- a/py_ecc/__init__.py
+++ b/py_ecc/__init__.py
@@ -1,17 +1,40 @@
+import importlib
 from importlib.metadata import (
     version as __version,
 )
-import sys
-
-from py_ecc import (
-    bls,
-    bls12_381,
-    bn128,
-    optimized_bls12_381,
-    optimized_bn128,
-    secp256k1,
+import sys as _sys
+from types import (
+    ModuleType,
+)
+from typing import (
+    List,
 )
 
-sys.setrecursionlimit(max(100000, sys.getrecursionlimit()))
+_sys.setrecursionlimit(max(100000, _sys.getrecursionlimit()))
 
 __version__ = __version("py_ecc")
+
+_lazy_imports = {
+    "bls": "py_ecc.bls",
+    "bls12_381": "py_ecc.bls12_381",
+    "bn128": "py_ecc.bn128",
+    "optimized_bls12_381": "py_ecc.optimized_bls12_381",
+    "optimized_bn128": "py_ecc.optimized_bn128",
+    "secp256k1": "py_ecc.secp256k1",
+}
+
+
+def _import_module(name: str) -> ModuleType:
+    module = importlib.import_module(_lazy_imports[name])
+    globals()[name] = module
+    return module
+
+
+def __getattr__(name: str) -> ModuleType:
+    if name in _lazy_imports:
+        return _import_module(name)
+    raise AttributeError(f"module 'py_ecc' has no attribute '{name}'")
+
+
+def __dir__() -> List[str]:
+    return list(_lazy_imports.keys()) + list(globals().keys())

--- a/tests/core/test_import_and_version.py
+++ b/tests/core/test_import_and_version.py
@@ -1,4 +1,17 @@
+import importlib
+
+from py_ecc import (
+    _lazy_imports,
+)
+
+
 def test_import_and_version():
     import py_ecc
 
     assert isinstance(py_ecc.__version__, str)
+
+
+def test_import_all_submodules():
+    # test import of all submodules due to use of lazy imports
+    for submod in _lazy_imports.values():
+        importlib.import_module(submod)


### PR DESCRIPTION
### What was wrong?

Import of `py_ecc` in other libs takes a long time.

Related to Issue #135 

### How was it fixed?

Lazy-load all submodules.
Added `import sys as _sys` to clarify intent on calling `dir(py_ecc)`.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/py_ecc/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/d61308ba-6036-4f28-86f4-11b538adaa04)
