### PR TITLE
set ecdsa_raw_recover to accept v values of 27 or 28

### DIFF
--- a/newsfragments/145.breaking.rst
+++ b/newsfragments/145.breaking.rst
@@ -1,0 +1,1 @@
+Set ``ecdsa_raw_recover`` to only accept ``v`` values of 27 or 28

--- a/py_ecc/secp256k1/secp256k1.py
+++ b/py_ecc/secp256k1/secp256k1.py
@@ -259,8 +259,8 @@ def ecdsa_raw_recover(msghash: bytes, vrs: Tuple[int, int, int]) -> "PlainPoint2
     :rtype: PlainPoint2D
     """
     v, r, s = vrs
-    if not (27 <= v <= 34):
-        raise ValueError(f"{v} must in range 27-31")
+    if v not in (27, 28):
+        raise ValueError(f"value of v was {v}, must be either 27 or 28")
     x = r
     xcubedaxb = (x * x * x + A * x + B) % P
     beta = pow(xcubedaxb, (P + 1) // 4, P)


### PR DESCRIPTION
### What was wrong?

Accepted values for `v` in `ecdsa_raw_recover` appear incorrect, and don't match error message.
Originally noted in `eth-keys` - https://github.com/ethereum/eth-keys/issues/67 - but same bug here.

### How was it fixed?

Set acceptable `v` values to be 27 or 28. See https://github.com/ethereum/eth-keys/pull/100 for detailed explanation. Though there, because the value passed was 0 or 1, it was noted that the value is aka `y-parity`. In this case, because it is passed as 27 or 28 and the doc string describes it as `v`, I've left the error message just referencing `v`.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/py_ecc/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/44f7fd9f-f8fd-4920-875c-98d43882c084)
