### PR TITLE
fix broken RTD links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Elliptic curve crypto in python including secp256k1, alt_bn128, and bls12_381.
 
 > **Warning**: This library contains some experimental code and has **NOT** been audited.
 
-Read the [documentation](https://py_ecc.readthedocs.io/).
+Read the [documentation](https://py-ecc.readthedocs.io/).
 
-View the [change log](https://py_ecc.readthedocs.io/en/latest/release_notes.html).
+View the [change log](https://py-ecc.readthedocs.io/en/latest/release_notes.html).
 
 ## Installation
 


### PR DESCRIPTION
### What was wrong?

ReadTheDocs links were incorrect, fixed!

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/py_ecc/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/0ed0ae7f-6e63-4047-b54b-d8bee7029698)
