### PR TITLE
Drop unneeded `cached-property` dependency

### DIFF
--- a/newsfragments/152.internal.rst
+++ b/newsfragments/152.internal.rst
@@ -1,0 +1,1 @@
+Remove unused ``cached-property`` dependency.

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(
     install_requires=[
         "eth-typing>=3.0.0",
         "eth-utils>=2.0.0",
-        "cached-property>=1.5.1",
     ],
     python_requires=">=3.9, <4",
     extras_require=extras_require,


### PR DESCRIPTION
### What was wrong?

 `cached-property` dependency is unused.

The only usage of `cached_property` is imported from `functools`[1], not the third-party module.

[1] https://github.com/ethereum/py_ecc/blob/c13300b23671b9ccf0d339f298096ce59c9103e2/py_ecc/fields/optimized_field_elements.py#L4-L5

### How was it fixed?

Dropped the dependency from `setup.py`.

All tests passed without the dependency.

### Todo:

- [x] Clean up commit history
- [ ] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/py_ecc/blob/main/newsfragments/README.md)

I'm not sure if a release note is needed for this change. If true, please tell me.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<https://i.pinimg.com/474x/cf/72/55/cf7255ae7344ce44e62f784fe160ca0d.jpg>)
