### PR TITLE
enable import * by adding __all__

### DIFF
--- a/newsfragments/153.internal.rst
+++ b/newsfragments/153.internal.rst
@@ -1,0 +1,1 @@
+Reenable ``from py_ecc import *`` post-lazyloading.

--- a/py_ecc/__init__.py
+++ b/py_ecc/__init__.py
@@ -23,6 +23,8 @@ _lazy_imports = {
     "secp256k1": "py_ecc.secp256k1",
 }
 
+__all__ = list(_lazy_imports.keys())
+
 
 def _import_module(name: str) -> ModuleType:
     module = importlib.import_module(_lazy_imports[name])


### PR DESCRIPTION
### What was wrong?

Lazy loading made `from py_ecc import *` not work.

### How was it fixed?

Adding an `__all__` to the top level `__init__.py` makes it work again.

``` python
# before

In [1]: %time import py_ecc
CPU times: user 3.81 ms, sys: 2.99 ms, total: 6.8 ms
Wall time: 5.97 ms

In [2]: %time from py_ecc import *
CPU times: user 40 μs, sys: 4 μs, total: 44 μs
Wall time: 49.4 μs

In [3]: bls
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
Cell In[3], line 1
----> 1 bls

NameError: name 'bls' is not defined

# after

In [1]: %time import py_ecc
CPU times: user 4.7 ms, sys: 977 μs, total: 5.67 ms
Wall time: 5.01 ms

In [2]: %time from py_ecc import *
CPU times: user 672 ms, sys: 14.8 ms, total: 687 ms
Wall time: 688 ms

In [3]: bls
Out[3]: <module 'py_ecc.bls' from '/home/pacrob/ethereum/py_ecc/py_ecc/bls/__init__.py'>
```

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/py_ecc/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/a6043246-f428-48ed-acc4-607ba249fcdb)
