### PR TITLE
Optimize ``multiply()`` and ``double()`` for point at infinity

### DIFF
--- a/newsfragments/156.performance.rst
+++ b/newsfragments/156.performance.rst
@@ -1,0 +1,1 @@
+Return early for point at infinity when possible for ``double()`` and ``multiply()`` methods.

--- a/py_ecc/bls12_381/bls12_381_curve.py
+++ b/py_ecc/bls12_381/bls12_381_curve.py
@@ -69,7 +69,8 @@ def is_inf(pt: GeneralPoint[Field]) -> bool:
 
 # Check that a point is on the curve defined by y**2 == x**3 + b
 def is_on_curve(pt: Point2D[Field], b: Field) -> bool:
-    if is_inf(pt) or pt is None:
+    if pt is None:
+        # point at infinity but mypy needs the `None` check
         return True
     x, y = pt
     return y**2 - x**3 == b
@@ -83,7 +84,8 @@ if not is_on_curve(G2, b2):
 
 # Elliptic curve doubling
 def double(pt: Point2D[Field]) -> Point2D[Field]:
-    if is_inf(pt) or pt is None:
+    if pt is None:
+        # point at infinity but mypy needs the `None` check
         return pt
     x, y = pt
     m = 3 * x**2 / (2 * y)
@@ -95,6 +97,7 @@ def double(pt: Point2D[Field]) -> Point2D[Field]:
 # Elliptic curve addition
 def add(p1: Point2D[Field], p2: Point2D[Field]) -> Point2D[Field]:
     if p1 is None or p2 is None:
+        # points at infinity but mypy needs the `None` check
         return p1 if p2 is None else p2
     x1, y1 = p1
     x2, y2 = p2
@@ -113,7 +116,7 @@ def add(p1: Point2D[Field], p2: Point2D[Field]) -> Point2D[Field]:
 
 # Elliptic curve point multiplication
 def multiply(pt: Point2D[Field], n: int) -> Point2D[Field]:
-    if n == 0:
+    if n == 0 or is_inf(pt):
         return None
     elif n == 1:
         return pt
@@ -134,6 +137,7 @@ w = FQ12([0, 1] + [0] * 10)
 # Convert P => -P
 def neg(pt: Point2D[Field]) -> Point2D[Field]:
     if pt is None:
+        # point at infinity but mypy needs the `None` check
         return None
     x, y = pt
     return (x, -y)
@@ -141,6 +145,7 @@ def neg(pt: Point2D[Field]) -> Point2D[Field]:
 
 def twist(pt: Point2D[FQP]) -> Point2D[FQ12]:
     if pt is None:
+        # point at infinity but mypy needs the `None` check
         return None
     _x, _y = pt
     # Field isomorphism from Z[p] / x**2 to Z[p] / x**2 - 2*x + 2

--- a/py_ecc/bls12_381/bls12_381_pairing.py
+++ b/py_ecc/bls12_381/bls12_381_pairing.py
@@ -33,6 +33,7 @@ log_ate_loop_count = 62
 # and evaluate it at T
 def linefunc(P1: Point2D[Field], P2: Point2D[Field], T: Point2D[Field]) -> Field:
     if P1 is None or P2 is None or T is None:  # No points-at-infinity allowed, sorry
+        # points at infinity but mypy needs the `None` check
         raise ValueError("Invalid input - no points-at-infinity allowed")
     x1, y1 = P1
     x2, y2 = P2
@@ -49,6 +50,7 @@ def linefunc(P1: Point2D[Field], P2: Point2D[Field], T: Point2D[Field]) -> Field
 
 def cast_point_to_fq12(pt: Point2D[FQ]) -> Point2D[FQ12]:
     if pt is None:
+        # point at infinity but mypy needs the `None` check
         return None
     x, y = pt
     return (FQ12([x.n] + [0] * 11), FQ12([y.n] + [0] * 11))

--- a/py_ecc/bn128/bn128_curve.py
+++ b/py_ecc/bn128/bn128_curve.py
@@ -62,7 +62,8 @@ def is_inf(pt: GeneralPoint[Field]) -> bool:
 
 # Check that a point is on the curve defined by y**2 == x**3 + b
 def is_on_curve(pt: Point2D[Field], b: Field) -> bool:
-    if is_inf(pt) or pt is None:
+    if pt is None:
+        # point at infinity but mypy needs the `None` check
         return True
     x, y = pt
     return y**2 - x**3 == b
@@ -76,7 +77,8 @@ if not is_on_curve(G2, b2):
 
 # Elliptic curve doubling
 def double(pt: Point2D[Field]) -> Point2D[Field]:
-    if is_inf(pt) or pt is None:
+    if pt is None:
+        # point at infinity but mypy needs the `None` check
         return pt
     x, y = pt
     m = 3 * x**2 / (2 * y)
@@ -88,6 +90,7 @@ def double(pt: Point2D[Field]) -> Point2D[Field]:
 # Elliptic curve addition
 def add(p1: Point2D[Field], p2: Point2D[Field]) -> Point2D[Field]:
     if p1 is None or p2 is None:
+        # points at infinity but mypy needs the `None` check
         return p1 if p2 is None else p2
     x1, y1 = p1
     x2, y2 = p2
@@ -106,7 +109,7 @@ def add(p1: Point2D[Field], p2: Point2D[Field]) -> Point2D[Field]:
 
 # Elliptic curve point multiplication
 def multiply(pt: Point2D[Field], n: int) -> Point2D[Field]:
-    if n == 0:
+    if n == 0 or is_inf(pt):
         return None
     elif n == 1:
         return pt
@@ -127,6 +130,7 @@ w = FQ12([0, 1] + [0] * 10)
 # Convert P => -P
 def neg(pt: Point2D[Field]) -> Point2D[Field]:
     if pt is None:
+        # point at infinity but mypy needs the `None` check
         return None
     x, y = pt
     return (x, -y)
@@ -134,6 +138,7 @@ def neg(pt: Point2D[Field]) -> Point2D[Field]:
 
 def twist(pt: Point2D[FQP]) -> Point2D[FQ12]:
     if pt is None:
+        # point at infinity but mypy needs the `None` check
         return None
     _x, _y = pt
     # Field isomorphism from Z[p] / x**2 to Z[p] / x**2 - 18*x + 82

--- a/py_ecc/bn128/bn128_pairing.py
+++ b/py_ecc/bn128/bn128_pairing.py
@@ -33,6 +33,7 @@ log_ate_loop_count = 63
 # and evaluate it at T
 def linefunc(P1: Point2D[Field], P2: Point2D[Field], T: Point2D[Field]) -> Field:
     if P1 is None or P2 is None or T is None:  # No points-at-infinity allowed, sorry
+        # points at infinity but mypy needs the `None` check
         raise ValueError("Invalid input - no points-at-infinity allowed")
     x1, y1 = P1
     x2, y2 = P2
@@ -49,6 +50,7 @@ def linefunc(P1: Point2D[Field], P2: Point2D[Field], T: Point2D[Field]) -> Field
 
 def cast_point_to_fq12(pt: Point2D[FQ]) -> Point2D[FQ12]:
     if pt is None:
+        # point at infinity but mypy needs the `None` check
         return None
     x, y = pt
     fq12_point = (FQ12([x.n] + [0] * 11), FQ12([y.n] + [0] * 11))

--- a/py_ecc/optimized_bls12_381/optimized_curve.py
+++ b/py_ecc/optimized_bls12_381/optimized_curve.py
@@ -94,6 +94,9 @@ if not is_on_curve(G2, b2):
 def double(
     pt: Optimized_Point3D[Optimized_Field],
 ) -> Optimized_Point3D[Optimized_Field]:
+    if is_inf(pt):
+        return pt
+
     x, y, z = pt
     W = 3 * x * x
     S = y * z

--- a/py_ecc/optimized_bls12_381/optimized_curve.py
+++ b/py_ecc/optimized_bls12_381/optimized_curve.py
@@ -18,6 +18,12 @@ curve_order = (
     52435875175126190479447740508185965837690552500527637822603658699938581184513
 )
 
+# Cache zero and one values for faster comparison and operations
+_FQ_ZERO = FQ.zero()
+_FQ_ONE = FQ.one()
+_FQ2_ZERO = FQ2.zero()
+_FQ2_ONE = FQ2.one()
+
 # Curve order should be prime
 if not pow(2, curve_order, curve_order) == 2:
     raise ValueError("Curve order is not prime")
@@ -56,12 +62,13 @@ G2 = (
             927553665492332455747201965776037880757740193453592970025027978793976877002675564980949289727957565575433344219582,  # noqa: E501
         )
     ),
-    FQ2.one(),
+    _FQ2_ONE,
 )
+
 # Point at infinity over FQ
-Z1 = (FQ.one(), FQ.one(), FQ.zero())
+Z1 = (_FQ_ONE, _FQ_ONE, _FQ_ZERO)
 # Point at infinity for twisted curve over FQ2
-Z2 = (FQ2.one(), FQ2.one(), FQ2.zero())
+Z2 = (_FQ2_ONE, _FQ2_ONE, _FQ2_ZERO)
 
 
 # Check if a point is the point at infinity
@@ -133,8 +140,9 @@ def add(
 def multiply(
     pt: Optimized_Point3D[Optimized_Field], n: int
 ) -> Optimized_Point3D[Optimized_Field]:
-    if n == 0:
-        return (pt[0].one(), pt[0].one(), pt[0].zero())
+    if n == 0 or is_inf(pt):
+        one, zero = pt[0].one(), pt[0].zero()
+        return (one, one, zero)
     elif n == 1:
         return pt
     elif not n % 2:

--- a/py_ecc/optimized_bls12_381/optimized_curve.py
+++ b/py_ecc/optimized_bls12_381/optimized_curve.py
@@ -98,6 +98,12 @@ def double(
         return pt
 
     x, y, z = pt
+
+    if y == y.__class__.zero():
+        # Doubling a point with y = 0 results in the point at infinity. There should be
+        # never be a point on the curve with y = 0 but this serves as safeguard.
+        return (pt[0].one(), pt[0].one(), pt[0].zero())
+
     W = 3 * x * x
     S = y * z
     B = x * y * S

--- a/py_ecc/optimized_bn128/optimized_curve.py
+++ b/py_ecc/optimized_bn128/optimized_curve.py
@@ -83,6 +83,12 @@ def double(
         return pt
 
     x, y, z = pt
+
+    if y == y.zero():
+        # Doubling a point with y = 0 results in the point at infinity. There should be
+        # never be a point on the curve with y = 0 but this serves as a safeguard.
+        return (x.one(), x.one(), x.zero())
+
     W = 3 * x * x
     S = y * z
     B = x * y * S

--- a/py_ecc/optimized_bn128/optimized_curve.py
+++ b/py_ecc/optimized_bn128/optimized_curve.py
@@ -79,6 +79,9 @@ if not is_on_curve(G2, b2):
 def double(
     pt: Optimized_Point3D[Optimized_Field],
 ) -> Optimized_Point3D[Optimized_Field]:
+    if is_inf(pt):
+        return pt
+
     x, y, z = pt
     W = 3 * x * x
     S = y * z

--- a/py_ecc/optimized_bn128/optimized_curve.py
+++ b/py_ecc/optimized_bn128/optimized_curve.py
@@ -125,7 +125,7 @@ def add(
 def multiply(
     pt: Optimized_Point3D[Optimized_Field], n: int
 ) -> Optimized_Point3D[Optimized_Field]:
-    if n == 0:
+    if n == 0 or is_inf(pt):
         return (pt[0].one(), pt[0].one(), pt[0].zero())
     elif n == 1:
         return pt

--- a/tests/core/test_bn128_and_bls12_381.py
+++ b/tests/core/test_bn128_and_bls12_381.py
@@ -273,6 +273,24 @@ def test_Z2_object(add, eq, double, FQ2, G2, is_inf, multiply, neg, twist, Z2):
     assert is_inf(twist(Z2))
 
 
+def test_double_when_y_is_zero(lib, FQ, FQ2, double, is_inf, Z1, Z2):
+    if lib not in [optimized_bn128, optimized_bls12_381]:
+        pytest.skip("Only testing optimized libraries")
+
+    # Test G1 point with y=0
+    # This simulates a 2-torsion point (which may not exist on the actual curve)
+    g1_point_y_zero = (FQ(1), FQ(0), FQ(1))
+    result_g1 = double(g1_point_y_zero)
+    assert is_inf(result_g1), "Doubling G1 point with y=0 should return infinity"
+    assert result_g1 == Z1, "Result should be in standard infinity form"
+
+    # Test G2 point with y=0
+    g2_point_y_zero = (FQ2([1, 0]), FQ2([0, 0]), FQ2([1, 0]))
+    result_g2 = double(g2_point_y_zero)
+    assert is_inf(result_g2), "Doubling G2 point with y=0 should return infinity"
+    assert result_g2 == Z2, "Result should be in standard infinity form"
+
+
 def test_none_point(lib, neg, twist):
     if lib not in [optimized_bn128, optimized_bls12_381]:
         pytest.skip()


### PR DESCRIPTION
### What was wrong?

Related to Issues 
- ethereum/execution-spec-tests#1894
- ethereum/execution-specs#1321

### How was it fixed?

- `double()`: The non-optimized implementation has a quick return for the point at infinity for `double()`, whereas the optimized does not have this. This was causing a slowdown for optimized vs non-optimized implementation in execution-specs when making a `subgroup_check()`.
- `multiply()`: Multiplication by infinity is infinity, quick return to skip unnecessary calculation when this is the case.

Additional changes:

- Add clarifying comments for point-at-infinity checks by checking `None` as this is required by mypy but not immediately obvious to a reader. Remove redundant `is_inf()` checks as that just checks for `None` again.
- Claude-assisted optimization for double() when y=0 was added here to be considered. I don't believe a point can be on the curve and have y=0 but maybe it's worth the quick check and return. Looking for a sanity check here.

### Todo:

- [x] Clean up commit history
- [x] ~~Add or update documentation related to these changes~~
- [x] Add entry to the [release notes](https://github.com/ethereum/py_ecc/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="693" height="662" alt="Screenshot 2025-07-14 at 17 59 37" src="https://github.com/user-attachments/assets/d38b5748-882f-4309-aa99-653fee223ea1" />

