### PR TITLE
Fix __pow__ recursion for s390x compatibility

### DIFF
--- a/py_ecc/fields/field_elements.py
+++ b/py_ecc/fields/field_elements.py
@@ -145,15 +145,23 @@ class FQ:
     def __rtruediv__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         return self.__rdiv__(other)
 
+    def inv(self: T_FQ) -> T_FQ:
+        return type(self)(prime_field_inv(self.n, self.field_modulus))
+
     def __pow__(self: T_FQ, other: int) -> T_FQ:
-        if other == 0:
-            return type(self)(1)
-        elif other == 1:
-            return type(self)(self.n)
-        elif other % 2 == 0:
-            return (self * self) ** (other // 2)
-        else:
-            return ((self * self) ** int(other // 2)) * self
+        if other < 0:
+            return self.inv() ** (-other)
+        res = type(self)(1)
+        base = self
+        exp = other
+
+        while exp > 0:
+            if exp % 2 == 1:
+                res = res * base
+            base = base * base
+            exp //= 2
+
+        return res
 
     def __eq__(self: T_FQ, other: Any) -> bool:
         if isinstance(other, FQ):
@@ -290,14 +298,19 @@ class FQP:
         return self.__div__(other)
 
     def __pow__(self: T_FQP, other: int) -> T_FQP:
-        o = type(self)([1] + [0] * (self.degree - 1))
-        t = self
-        while other > 0:
-            if other & 1:
-                o = o * t
-            other >>= 1
-            t = t * t
-        return o
+        if other < 0:
+            return self.inv() ** (-other)
+        res = type(self)([1] + [0] * (self.degree - 1))
+        base = self
+        exp = other
+
+        while exp > 0:
+            if exp % 2 == 1:
+                res = res * base
+            base = base * base
+            exp //= 2
+
+        return res
 
     # Extended euclidean algorithm used to find the modular inverse
     def inv(self: T_FQP) -> T_FQP:

--- a/py_ecc/fields/optimized_field_elements.py
+++ b/py_ecc/fields/optimized_field_elements.py
@@ -157,15 +157,23 @@ class FQ:
     def __rtruediv__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         return self.__rdiv__(other)
 
+    def inv(self: T_FQ) -> T_FQ:
+        return type(self)(prime_field_inv(self.n, self.field_modulus))
+
     def __pow__(self: T_FQ, other: int) -> T_FQ:
-        if other == 0:
-            return type(self)(1)
-        elif other == 1:
-            return type(self)(self.n)
-        elif other % 2 == 0:
-            return (self * self) ** (other // 2)
-        else:
-            return ((self * self) ** int(other // 2)) * self
+        if other < 0:
+            return self.inv() ** (-other)
+        res = type(self)(1)
+        base = self
+        exp = other
+
+        while exp > 0:
+            if exp % 2 == 1:
+                res = res * base
+            base = base * base
+            exp //= 2
+
+        return res
 
     def __eq__(self: T_FQ, other: Any) -> bool:
         if isinstance(other, FQ):


### PR DESCRIPTION
### What was wrong?

In Debian, where the tests of this Python package across multiple architectures, it was discovered that the pairing tests fail on s390x.

Supercedes PR #159.

### How was it fixed?

Fix the recursion issue by converting FQP.__pow__ from a recursive to an iterative square-and-multiply implementation. The new implementation is mathematically equivalent, handles negative exponents (which the old version didn't), and won't hit maximum recursion depth on large exponents. With this change tests are fully passing on architecture s390x in Debian.

Additionally, also convert the FQ classes to use the same iterative square-and-multiply algorithm. Thehey were not seen failing on s390, but probably because tests only run with smaller exponents on those functions.

Proof that latest version also has all tests passing on s390x: https://autopkgtest.ubuntu.com/results/autopkgtest-resolute-otto-ppa/resolute/s390x/p/python-py-ecc/20260328_153048_a9f0e@/log.gz

### Todo:

- [x] Clean up commit history
- N/A Add or update documentation related to these changes
- N/A Add entry to the [release notes](https://github.com/ethereum/py_ecc/blob/main/newsfragments/README.md)

#### Cute Animal Picture

:cat: 