### PR TITLE
fix: reject booleans in isinstance int checks

### DIFF
--- a/py_ecc/bls/ciphersuites.py
+++ b/py_ecc/bls/ciphersuites.py
@@ -263,8 +263,7 @@ class BaseG2Ciphersuite(ABC):
         PKs: Sequence[BLSPubkey],
         messages: Sequence[bytes],
         signature: BLSSignature,
-    ) -> bool:
-        ...
+    ) -> bool: ...
 
 
 class G2Basic(BaseG2Ciphersuite):

--- a/py_ecc/bls/ciphersuites.py
+++ b/py_ecc/bls/ciphersuites.py
@@ -263,7 +263,8 @@ class BaseG2Ciphersuite(ABC):
         PKs: Sequence[BLSPubkey],
         messages: Sequence[bytes],
         signature: BLSSignature,
-    ) -> bool: ...
+    ) -> bool:
+        ...
 
 
 class G2Basic(BaseG2Ciphersuite):

--- a/py_ecc/bls/ciphersuites.py
+++ b/py_ecc/bls/ciphersuites.py
@@ -24,9 +24,6 @@ from eth_utils import (
 from py_ecc.fields import (
     optimized_bls12_381_FQ12 as FQ12,
 )
-from py_ecc.utils import (
-    is_integer,
-)
 from py_ecc.optimized_bls12_381 import (
     G1,
     Z1,
@@ -37,6 +34,9 @@ from py_ecc.optimized_bls12_381 import (
     multiply,
     neg,
     pairing,
+)
+from py_ecc.utils import (
+    is_integer,
 )
 
 from .g2_primitives import (

--- a/py_ecc/bls/ciphersuites.py
+++ b/py_ecc/bls/ciphersuites.py
@@ -24,6 +24,9 @@ from eth_utils import (
 from py_ecc.fields import (
     optimized_bls12_381_FQ12 as FQ12,
 )
+from py_ecc.utils import (
+    is_integer,
+)
 from py_ecc.optimized_bls12_381 import (
     G1,
     Z1,
@@ -64,7 +67,7 @@ class BaseG2Ciphersuite(ABC):
     #
     @staticmethod
     def _is_valid_privkey(privkey: int) -> bool:
-        return isinstance(privkey, int) and privkey > 0 and privkey < curve_order
+        return is_integer(privkey) and privkey > 0 and privkey < curve_order
 
     @staticmethod
     def _is_valid_pubkey(pubkey: bytes) -> bool:

--- a/py_ecc/fields/field_elements.py
+++ b/py_ecc/fields/field_elements.py
@@ -14,6 +14,7 @@ from typing import (
 
 from py_ecc.utils import (
     deg,
+    is_integer,
     poly_rounded_div,
     prime_field_inv,
 )
@@ -50,7 +51,7 @@ class FQ:
 
         if isinstance(val, FQ):
             self.n = val.n
-        elif isinstance(val, int):
+        elif is_integer(val):
             self.n = val % self.field_modulus
         else:
             raise TypeError(
@@ -60,7 +61,7 @@ class FQ:
     def __add__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         if isinstance(other, FQ):
             on = other.n
-        elif isinstance(other, int):
+        elif is_integer(other):
             on = other
         else:
             raise TypeError(
@@ -72,7 +73,7 @@ class FQ:
     def __mul__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         if isinstance(other, FQ):
             on = other.n
-        elif isinstance(other, int):
+        elif is_integer(other):
             on = other
         else:
             raise TypeError(
@@ -90,7 +91,7 @@ class FQ:
     def __rsub__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         if isinstance(other, FQ):
             on = other.n
-        elif isinstance(other, int):
+        elif is_integer(other):
             on = other
         else:
             raise TypeError(
@@ -102,7 +103,7 @@ class FQ:
     def __sub__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         if isinstance(other, FQ):
             on = other.n
-        elif isinstance(other, int):
+        elif is_integer(other):
             on = other
         else:
             raise TypeError(
@@ -114,7 +115,7 @@ class FQ:
     def __div__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         if isinstance(other, FQ):
             on = other.n
-        elif isinstance(other, int):
+        elif is_integer(other):
             on = other
         else:
             raise TypeError(
@@ -131,7 +132,7 @@ class FQ:
     def __rdiv__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         if isinstance(other, FQ):
             on = other.n
-        elif isinstance(other, int):
+        elif is_integer(other):
             on = other
         else:
             raise TypeError(
@@ -158,7 +159,7 @@ class FQ:
     def __eq__(self: T_FQ, other: Any) -> bool:
         if isinstance(other, FQ):
             return self.n == other.n
-        elif isinstance(other, int):
+        elif is_integer(other):
             return self.n == other
         else:
             raise TypeError(
@@ -180,7 +181,7 @@ class FQ:
     def __lt__(self: T_FQ, other: IntOrFQ) -> bool:
         if isinstance(other, FQ):
             on = other.n
-        elif isinstance(other, int):
+        elif is_integer(other):
             on = other
         else:
             raise TypeError(

--- a/py_ecc/fields/optimized_field_elements.py
+++ b/py_ecc/fields/optimized_field_elements.py
@@ -15,6 +15,7 @@ from typing import (
 
 from py_ecc.utils import (
     deg,
+    is_integer,
     prime_field_inv,
 )
 
@@ -35,7 +36,7 @@ IntOrFQ = Union[int, "FQ"]
 
 
 def mod_int(x: IntOrFQ, n: int) -> int:
-    if isinstance(x, int):
+    if is_integer(x):
         return x % n
     elif isinstance(x, FQ):
         return x.n % n
@@ -59,7 +60,7 @@ class FQ:
 
         if isinstance(val, FQ):
             self.n = val.n
-        elif isinstance(val, int):
+        elif is_integer(val):
             self.n = val % self.field_modulus
         else:
             raise TypeError(
@@ -69,7 +70,7 @@ class FQ:
     def __add__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         if isinstance(other, FQ):
             on = other.n
-        elif isinstance(other, int):
+        elif is_integer(other):
             on = other
         else:
             raise TypeError(
@@ -81,7 +82,7 @@ class FQ:
     def __mul__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         if isinstance(other, FQ):
             on = other.n
-        elif isinstance(other, int):
+        elif is_integer(other):
             on = other
         else:
             raise TypeError(
@@ -99,7 +100,7 @@ class FQ:
     def __rsub__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         if isinstance(other, FQ):
             on = other.n
-        elif isinstance(other, int):
+        elif is_integer(other):
             on = other
         else:
             raise TypeError(
@@ -111,7 +112,7 @@ class FQ:
     def __sub__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         if isinstance(other, FQ):
             on = other.n
-        elif isinstance(other, int):
+        elif is_integer(other):
             on = other
         else:
             raise TypeError(
@@ -126,7 +127,7 @@ class FQ:
     def __div__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         if isinstance(other, FQ):
             on = other.n
-        elif isinstance(other, int):
+        elif is_integer(other):
             on = other
         else:
             raise TypeError(
@@ -143,7 +144,7 @@ class FQ:
     def __rdiv__(self: T_FQ, other: IntOrFQ) -> T_FQ:
         if isinstance(other, FQ):
             on = other.n
-        elif isinstance(other, int):
+        elif is_integer(other):
             on = other
         else:
             raise TypeError(
@@ -170,7 +171,7 @@ class FQ:
     def __eq__(self: T_FQ, other: Any) -> bool:
         if isinstance(other, FQ):
             return self.n == other.n
-        elif isinstance(other, int):
+        elif is_integer(other):
             return self.n == other
         else:
             raise TypeError(
@@ -192,7 +193,7 @@ class FQ:
     def __lt__(self: T_FQ, other: IntOrFQ) -> bool:
         if isinstance(other, FQ):
             on = other.n
-        elif isinstance(other, int):
+        elif is_integer(other):
             on = other
         else:
             raise TypeError(
@@ -242,7 +243,7 @@ class FQP:
 
         # Not converting coeffs to FQ or explicitly making them integers
         # for performance reasons
-        if isinstance(coeffs[0], int):
+        if is_integer(coeffs[0]):
             self.coeffs: tuple[IntOrFQ, ...] = tuple(
                 coeff % self.field_modulus for coeff in coeffs
             )
@@ -277,7 +278,7 @@ class FQP:
         raise NotImplementedError("Modulo Operation not yet supported by fields")
 
     def __mul__(self: T_FQP, other: int | T_FQP) -> T_FQP:
-        if isinstance(other, int):
+        if is_integer(other):
             return type(self)(
                 [int(c) * other % self.field_modulus for c in self.coeffs]
             )
@@ -302,7 +303,7 @@ class FQP:
         return self * other
 
     def __div__(self: T_FQP, other: int | T_FQP) -> T_FQP:
-        if isinstance(other, int):
+        if is_integer(other):
             return type(self)(
                 [
                     int(c)

--- a/py_ecc/utils.py
+++ b/py_ecc/utils.py
@@ -21,11 +21,12 @@ IntOrFQ = Union[int, "FQ"]
 
 
 def is_integer(value: object) -> TypeGuard[int]:
-    """Return True iff value is an int but not a bool.
+    """
+    Return True iff value is a strict integer (not a bool).
 
     Python's bool is a subclass of int, so isinstance(True, int) is True.
     In cryptographic code a boolean accepted as an integer can produce
-    incorrect results silently.  TypeGuard[int] preserves mypy type narrowing.
+    incorrect results silently. TypeGuard[int] preserves mypy type narrowing.
     """
     return isinstance(value, int) and not isinstance(value, bool)
 

--- a/py_ecc/utils.py
+++ b/py_ecc/utils.py
@@ -19,6 +19,18 @@ if TYPE_CHECKING:
 IntOrFQ = Union[int, "FQ"]
 
 
+def is_integer(value: object) -> bool:
+    """
+    Return True if value is an int but not a bool.
+
+    Python's bool is a subclass of int, so isinstance(True, int) returns True.
+    In cryptographic code this is dangerous - a boolean passed where an integer
+    is expected can produce incorrect results silently.  Use this helper wherever
+    an explicit integer (not a boolean) is required.
+    """
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
 def prime_field_inv(a: int, n: int) -> int:
     """
     Extended euclidean algorithm to find modular inverses for integers

--- a/py_ecc/utils.py
+++ b/py_ecc/utils.py
@@ -3,6 +3,7 @@ from collections.abc import (
 )
 from typing import (
     TYPE_CHECKING,
+    TypeGuard,
     Union,
     cast,
 )
@@ -19,14 +20,12 @@ if TYPE_CHECKING:
 IntOrFQ = Union[int, "FQ"]
 
 
-def is_integer(value: object) -> bool:
-    """
-    Return True if value is an int but not a bool.
+def is_integer(value: object) -> TypeGuard[int]:
+    """Return True iff value is an int but not a bool.
 
-    Python's bool is a subclass of int, so isinstance(True, int) returns True.
-    In cryptographic code this is dangerous - a boolean passed where an integer
-    is expected can produce incorrect results silently.  Use this helper wherever
-    an explicit integer (not a boolean) is required.
+    Python's bool is a subclass of int, so isinstance(True, int) is True.
+    In cryptographic code a boolean accepted as an integer can produce
+    incorrect results silently.  TypeGuard[int] preserves mypy type narrowing.
     """
     return isinstance(value, int) and not isinstance(value, bool)
 

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
 
 from py_ecc.utils import (
+    is_integer,
     prime_field_inv,
 )
 
@@ -16,3 +17,17 @@ from py_ecc.utils import (
 )
 def test_prime_field_inv(a, n, result):
     assert prime_field_inv(a, n) % n == result
+
+
+def test_rejects_booleans():
+    # booleans must be rejected even though bool is a subclass of int
+    assert not is_integer(True)
+    assert not is_integer(False)
+    # plain integers must be accepted
+    assert is_integer(0)
+    assert is_integer(42)
+    assert is_integer(-1)
+    # non-integers must be rejected
+    assert not is_integer(1.0)
+    assert not is_integer("1")
+    assert not is_integer(None)


### PR DESCRIPTION
Fixes #30

Python's `bool` is a subclass of `int`, so `isinstance(True, int)` returns `True`. In cryptographic code this is dangerous - a boolean passed where an integer is expected can produce incorrect results silently.

**Changes:**
- Adds `is_integer()` utility in `py_ecc/utils.py` that explicitly rejects booleans
- Updates field arithmetic checks in `field_elements.py`, `optimized_field_elements.py`, `ciphersuites.py` to use it
- Adds tests verifying booleans are rejected and integers accepted